### PR TITLE
Require error

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cjs": true
   },
   "dependencies": {
-    "d3-require": "https://github.com/d3/d3-require#7969f63b095bd0bb45ad79faca735c1ea33b5d50",
+    "d3-require": "1.2.0",
     "esm": "^3.0.5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.3.0",
   "license": "ISC",
   "main": "dist/notebook-stdlib.umd.js",
-  "module": "dist/notebook-stdlib.js",
+  "module": "src/index.js",
   "author": {
     "name": "Observable, Inc.",
     "url": "https://observablehq.com"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "cjs": true
   },
   "dependencies": {
-    "d3-require": "^1.1.0",
+    "d3-require": "https://github.com/d3/d3-require#7969f63b095bd0bb45ad79faca735c1ea33b5d50",
     "esm": "^3.0.5"
   },
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,10 @@ function config(output) {
       node(),
       terser({
         toplevel: output.format === "es",
-        output: {preamble: copyright}
+        output: {preamble: copyright},
+        mangle: {
+          reserved: ["RequireError"]
+        }
       })
     ],
     output

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,9 +255,9 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
-d3-require@^1.1.0:
+"d3-require@https://github.com/d3/d3-require#7969f63b095bd0bb45ad79faca735c1ea33b5d50":
   version "1.1.4"
-  resolved "https://registry.yarnpkg.com/d3-require/-/d3-require-1.1.4.tgz#f5b229aaab5586bfcd67383c78652147d3def72b"
+  resolved "https://github.com/d3/d3-require#7969f63b095bd0bb45ad79faca735c1ea33b5d50"
 
 dashdash@^1.12.0:
   version "1.14.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -255,9 +255,9 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
-"d3-require@https://github.com/d3/d3-require#7969f63b095bd0bb45ad79faca735c1ea33b5d50":
-  version "1.1.4"
-  resolved "https://github.com/d3/d3-require#7969f63b095bd0bb45ad79faca735c1ea33b5d50"
+d3-require@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/d3-require/-/d3-require-1.2.0.tgz#a840fc88e4b7f3bc49dac91eb16615c1df20b42a"
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
Rely on d3-require's special error branch, and switch `module` entry to source.