### PR TITLE
Wrap with span, not div.

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -5,5 +5,5 @@ export default template(function(string) {
   template.innerHTML = string.trim();
   return document.importNode(template.content, true);
 }, function() {
-  return document.createElement("div");
+  return document.createElement("span");
 });

--- a/src/md.js
+++ b/src/md.js
@@ -4,7 +4,7 @@ export default function(require) {
   return function() {
     return require("marked@0.3.12/marked.min.js").then(function(marked) {
       return template(function(string) {
-        var root = document.createElement("div");
+        var root = document.createElement("span");
         root.innerHTML = marked(string, {langPrefix: ""}).trim();
         var code = root.querySelectorAll("pre code[class]");
         if (code.length > 0) {
@@ -17,7 +17,7 @@ export default function(require) {
         }
         return root;
       }, function() {
-        return document.createElement("div");
+        return document.createElement("span");
       });
     });
   };


### PR DESCRIPTION
Previously, there was an implicit DIV when using an html or md tagged template literal that returns more than one node. For example:

```js
html`Hello, <i>world</i>!`
```

This implicit DIV is weird if you’re embedding the HTML inside something else (rather than as a top-level cell value); it’s better to use a container that doesn’t affect the content layout, hence SPAN.

Fixes #73.