### PR TITLE
Lazy DOM.download.

### DIFF
--- a/src/dom/download.js
+++ b/src/dom/download.js
@@ -1,11 +1,31 @@
-export default function(object, name, label) {
-  var a = document.createElement("a"),
-      b = a.appendChild(document.createElement("button"));
-  b.textContent = label == null ? "Download" : label;
-  a.download = name == null ? "untitled" : name;
-  a.onclick = function() {
-    var url = a.href = URL.createObjectURL(object);
-    setTimeout(function() { URL.revokeObjectURL(url); }, 50);
+export default function(value, name = "untitled", label = "Save") {
+  const a = document.createElement("a");
+  const b = a.appendChild(document.createElement("button"));
+  b.textContent = label;
+  a.download = name;
+
+  async function reset() {
+    await new Promise(requestAnimationFrame);
+    URL.revokeObjectURL(a.href);
+    a.removeAttribute("href");
+    b.textContent = label;
+    b.disabled = false;
+  }
+
+  a.onclick = async event => {
+    b.disabled = true;
+    if (a.href) return reset(); // Already saved.
+    b.textContent = "Saving…";
+    try {
+      const object = await (typeof value === "function" ? value() : value);
+      b.textContent = "Download";
+      a.href = URL.createObjectURL(object);
+    } catch (ignore) {
+      b.textContent = label;
+    }
+    if (event.eventPhase) return reset(); // Already downloaded.
+    b.disabled = false;
   };
+
   return a;
 }


### PR DESCRIPTION
Fixes #75.

* Allows the *value* to be specified optionally as a promise, a function, or a function that returns a promise. If a promise or a function that returns a promise, the first click changes the label to “Saving…” and disables the button while waiting for the promise to resolve, then changes the label to “Download”, and the second click will do the download.

* If the *value* is specified as a function, it is re-evaluated on each click.

* Changes the default label to “Save” instead of “Download” (for better compatibility with asynchronous values, where the “Saving…” and “Download” labels are applied internally and not customizable).
