### PR TITLE
Remove existing fragment identifier in DOM.uid

### DIFF
--- a/src/dom/uid.js
+++ b/src/dom/uid.js
@@ -6,7 +6,7 @@ export default function(name) {
 
 function Id(id) {
   this.id = id;
-  this.href = window.location.href.replace(window.location.hash, "") + "#" + id;
+  this.href = new URL(`#${id}`, location) + "";
 }
 
 Id.prototype.toString = function() {

--- a/src/dom/uid.js
+++ b/src/dom/uid.js
@@ -6,7 +6,7 @@ export default function(name) {
 
 function Id(id) {
   this.id = id;
-  this.href = window.location.href + "#" + id;
+  this.href = window.location.href.replace(window.location.hash, "") + "#" + id;
 }
 
 Id.prototype.toString = function() {


### PR DESCRIPTION
Appending `"#" + id` to `window.location` results in UID hrefs with _two_ fragment identifiers. This commit removes the existing fragment identifier before appending the new one.

For an example of the currently-broken behavior, see https://observablehq.com/@mbostock/svg-clipping-test#foo. The preexisting fragment identifier `#foo` returns it to broken clipping.