### PR TITLE
FileAttachments: Stdlib Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ For examples, see https://observablehq.com/@observablehq/standard-library.
 
 * [DOM](#dom) - create HTML and SVG elements.
 * [Files](#files) - read local files into memory.
+* [FileAttachments](#file_attachments) - read remote files.
 * [Generators](#generators) - utilities for generators and iterators.
 * [Promises](#promises) - utilities for promises.
 * [require](#require) - load third-party libraries.
@@ -271,6 +272,100 @@ A data URL may be significantly less efficient than [URL.createObjectURL](https:
   invalidation.then(() => URL.revokeObjectURL(image.src));
   return image;
 }
+```
+
+### File Attachments
+
+See [File Attachments](https://observablehq.com/@observablehq/file-attachments) on Observable for examples.
+
+<a href="#FileAttachments" name="FileAttachments">#</a> <br>FileAttachments</b>(<i>resolve</i>) [<>](https://github.com/observablehq/stdlib/blob/master/src/fileAttachment.js "Source")
+
+The **FileAttachments** function exported by the standard library is an abstract class that can be used to fetch files by name from remote URLs. To make it concrete, you call it with a *resolve* function, which is an async function that takes a *name* and returns a URL at which the file of that name may be loaded. For example:
+
+```js
+const FileAttachment = FileAttachments((name) =>
+  `https://my.server/notebooks/demo/${name}`
+);
+```
+
+Or, with a more complex example, calling an API to produce temporary URLs:
+
+```js
+const FileAttachment = FileAttachments(async (name) =>
+  if (cachedUrls.has(name)) return cachedUrls.get(name);
+  const url = await fetchSignedFileUrl(notebookId, name);
+  cachedUrls.set(name, url);
+  return url;
+);
+```
+
+Once you have your **FileAttachment** function defined, you can call it from notebook code:
+
+```js
+photo = FileAttachment("sunset.jpg")
+```
+
+FileAttachments work similarly to the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch), providing methods that return promises to the file’s contents in a handful of convenient forms.
+
+<a href="#FileAttachment_url" name="FileAttachment_url">#</a> FileAttachment(name).<b>url</b>() [<>](https://github.com/observablehq/stdlib/blob/master/src/fileAttachment.js "Source")
+
+Returns a promise to the URL at which the file may be retrieved.
+
+```js
+const url = await FileAttachment("file.txt").url();
+```
+
+<a href="#FileAttachment_text" name="FileAttachment_text">#</a> FileAttachment(name).<b>text</b>() [<>](https://github.com/observablehq/stdlib/blob/master/src/fileAttachment.js "Source")
+
+Returns a promise to the file’s contents as a JavaScript string.
+
+```js
+const data = d3.csvParse(await FileAttachment("cars.csv").text());
+```
+
+<a href="#FileAttachment_json" name="FileAttachment_json">#</a> FileAttachment(name).<b>json</b>() [<>](https://github.com/observablehq/stdlib/blob/master/src/fileAttachment.js "Source")
+
+Returns a promise to the file’s contents, parsed as JSON into JavaScript values.
+
+```js
+const logs = await FileAttachment("weekend-logs.json").json();
+```
+
+<a href="#FileAttachment_image" name="FileAttachment_image">#</a> FileAttachment(name).<b>image</b>() [<>](https://github.com/observablehq/stdlib/blob/master/src/fileAttachment.js "Source")
+
+Returns a promise to a file loaded as an [HTML Image](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/Image). Note that the promise won't resolve until the image has finished loading — making this a useful value to pass to other cells that need to process the image, or paint it into a `<canvas>`.
+
+```js
+const image = await FileAttachment("sunset.jpg").image();
+```
+
+<a href="#FileAttachment_arrayBuffer" name="FileAttachment_arrayBuffer">#</a> FileAttachment(name).<b>arrayBuffer</b>() [<>](https://github.com/observablehq/stdlib/blob/master/src/fileAttachment.js "Source")
+
+Returns a promise to the file’s contents as an [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer).
+
+```js
+const city = shapefile.read(await FileAttachment("sf.shp").arrayBuffer());
+```
+
+<a href="#FileAttachment_stream" name="FileAttachment_stream">#</a> FileAttachment(name).<b>stream</b>() [<>](https://github.com/observablehq/stdlib/blob/master/src/fileAttachment.js "Source")
+
+Returns a promise to a [Stream](https://developer.mozilla.org/en-US/docs/Web/API/Streams_API) of the file’s contents.
+
+```js
+const stream = await FileAttachment("metrics.csv").stream();
+const reader = stream.getReader();
+let done, value;
+while (({done, value} = await reader.read()), !done) {
+  yield value;
+}
+```
+
+<a href="#FileAttachment_blob" name="FileAttachment_blob">#</a> FileAttachment(name).<b>blob</b>() [<>](https://github.com/observablehq/stdlib/blob/master/src/fileAttachment.js "Source")
+
+Returns a promise to a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) containing the raw contents of the file.
+
+```js
+const blob = await FileAttachment("binary-data.dat").blob();
 ```
 
 ### Generators

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "dist/**/*.js"
   ],
   "dependencies": {
-    "d3-require": "^1.2.0",
+    "d3-require": "^1.2.4",
     "marked": "https://github.com/observablehq/marked.git#94c6b946f462fd25db4465d71a6859183f86c57f"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@observablehq/stdlib",
-  "version": "3.1.1",
+  "version": "3.2.0-rc.1",
+  "publishConfig": {
+    "tag": "next"
+  },
   "license": "ISC",
   "main": "dist/stdlib.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observablehq/stdlib",
-  "version": "3.2.0-rc.4",
+  "version": "3.2.0-rc.5",
   "publishConfig": {
     "tag": "next"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observablehq/stdlib",
-  "version": "3.2.0-rc.2",
+  "version": "3.2.0-rc.3",
   "publishConfig": {
     "tag": "next"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observablehq/stdlib",
-  "version": "3.2.0-rc.1",
+  "version": "3.2.0-rc.2",
   "publishConfig": {
     "tag": "next"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observablehq/stdlib",
-  "version": "3.2.0-rc.3",
+  "version": "3.2.0-rc.4",
   "publishConfig": {
     "tag": "next"
   },

--- a/src/dom/uid.js
+++ b/src/dom/uid.js
@@ -6,7 +6,7 @@ export default function(name) {
 
 function Id(id) {
   this.id = id;
-  this.href = window.location.href.replace(window.location.hash, "") + "#" + id;
+  this.href = new URL(`#${id}`, location) + "";
 }
 
 Id.prototype.toString = function() {

--- a/src/dom/uid.js
+++ b/src/dom/uid.js
@@ -6,7 +6,7 @@ export default function(name) {
 
 function Id(id) {
   this.id = id;
-  this.href = window.location.href + "#" + id;
+  this.href = window.location.href.replace(window.location.hash, "") + "#" + id;
 }
 
 Id.prototype.toString = function() {

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -4,37 +4,40 @@ async function remote_fetch(url) {
   return response;
 }
 
-export default function FileAttachment(resolve) {
-  return class FileAttachment {
-    constructor(name) {
-      Object.defineProperties(this, {
-        name: {value: name, enumerable: true}
+class FileAttachment {
+  constructor(resolve, name) {
+    Object.defineProperties(this, {
+      _resolve: {value: resolve},
+      name: {value: name, enumerable: true}
+    });
+  }
+  async url() {
+    return this._resolve(this.name);
+  }
+  async blob() {
+    return (await remote_fetch(await this.url())).blob();
+  }
+  async arrayBuffer() {
+    return (await remote_fetch(await this.url())).arrayBuffer();
+  }
+  async text() {
+    return (await remote_fetch(await this.url())).text();
+  }
+  async json() {
+    return (await remote_fetch(await this.url())).json();
+  }
+  async image() {
+    return new Promise((resolve, reject) => {
+      const img = document.createElement("img");
+      img.onload = () => resolve(img);
+      img.onerror = () => reject(new Error("Unable to load image"));
+      this.url().then(url => {
+        img.src = url;
       });
-    }
-    async url() {
-      return resolve(this.name);
-    }
-    async blob() {
-      return (await remote_fetch(await this.url())).blob();
-    }
-    async arrayBuffer() {
-      return (await remote_fetch(await this.url())).arrayBuffer();
-    }
-    async text() {
-      return (await remote_fetch(await this.url())).text();
-    }
-    async json() {
-      return (await remote_fetch(await this.url())).json();
-    }
-    async image() {
-      return new Promise((resolve, reject) => {
-        const img = document.createElement("img");
-        img.onload = () => resolve(img);
-        img.onerror = () => reject(new Error("Unable to load image"));
-        this.url().then(url => {
-          img.src = url;
-        });
-      });
-    }
-  };
+    });
+  }
+}
+
+export default function ResolveFileAttachment(resolve) {
+  return (name) => new FileAttachment(resolve, name);
 }

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -1,6 +1,6 @@
 async function remote_fetch(file) {
   const response = await fetch(await file.url());
-  if (!response.ok) throw new Error("Unable to load file");
+  if (!response.ok) throw new Error(`Unable to load file: ${file.name}`);
   return response;
 }
 

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -29,11 +29,12 @@ class FileAttachment {
     return (await remote_fetch(this)).json();
   }
   async image() {
+    const url = await this.url();
     return new Promise(async (resolve, reject) => {
       const img = new Image;
       img.onload = () => resolve(img);
       img.onerror = () => reject(new Error(`Unable to load file: ${this.name}`));
-      img.src = await this.url();
+      img.src = url;
     });
   }
 }

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -12,7 +12,9 @@ class FileAttachment {
     });
   }
   async url() {
-    return this._resolve(this.name);
+    const url = await this._resolve(this.name);
+    if (url == null) throw new Error(`Unknown file: ${this.name}`);
+    return url;
   }
   async blob() {
     return (await remote_fetch(await this.url())).blob();

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -29,13 +29,11 @@ class FileAttachment {
     return (await remote_fetch(this)).json();
   }
   async image() {
-    return new Promise((resolve, reject) => {
-      const img = document.createElement("img");
+    return new Promise(async (resolve, reject) => {
+      const img = new Image;
       img.onload = () => resolve(img);
-      img.onerror = () => reject(new Error("Unable to load image"));
-      this.url().then(url => {
-        img.src = url;
-      });
+      img.onerror = () => reject(new Error(`Unable to load file: ${this.name}`));
+      img.src = await this.url();
     });
   }
 }

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -1,5 +1,5 @@
-async function remote_fetch(url) {
-  const response = await fetch(url);
+async function remote_fetch(file) {
+  const response = await fetch(await file.url());
   if (!response.ok) throw new Error("Unable to load file");
   return response;
 }
@@ -17,16 +17,16 @@ class FileAttachment {
     return url;
   }
   async blob() {
-    return (await remote_fetch(await this.url())).blob();
+    return (await remote_fetch(this)).blob();
   }
   async arrayBuffer() {
-    return (await remote_fetch(await this.url())).arrayBuffer();
+    return (await remote_fetch(this)).arrayBuffer();
   }
   async text() {
-    return (await remote_fetch(await this.url())).text();
+    return (await remote_fetch(this)).text();
   }
   async json() {
-    return (await remote_fetch(await this.url())).json();
+    return (await remote_fetch(this)).json();
   }
   async image() {
     return new Promise((resolve, reject) => {

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -28,6 +28,9 @@ class FileAttachment {
   async json() {
     return (await remote_fetch(this)).json();
   }
+  async stream() {
+    return (await remote_fetch(this)).body;
+  }
   async image() {
     const url = await this.url();
     return new Promise((resolve, reject) => {

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -1,0 +1,40 @@
+async function remote_fetch(url) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error("Unable to load file");
+  return response;
+}
+
+export default function FileAttachment(resolve) {
+  return class FileAttachment {
+    constructor(name) {
+      Object.defineProperties(this, {
+        name: {value: name, enumerable: true}
+      });
+    }
+    async url() {
+      return resolve(this.name);
+    }
+    async blob() {
+      return (await remote_fetch(await this.url())).blob();
+    }
+    async arrayBuffer() {
+      return (await remote_fetch(await this.url())).arrayBuffer();
+    }
+    async text() {
+      return (await remote_fetch(await this.url())).text();
+    }
+    async json() {
+      return (await remote_fetch(await this.url())).json();
+    }
+    async image() {
+      return new Promise((resolve, reject) => {
+        const img = document.createElement("img");
+        img.onload = () => resolve(img);
+        img.onerror = () => reject(new Error("Unable to load image"));
+        this.url().then(url => {
+          img.src = url;
+        });
+      });
+    }
+  };
+}

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -30,7 +30,7 @@ class FileAttachment {
   }
   async image() {
     const url = await this.url();
-    return new Promise(async (resolve, reject) => {
+    return new Promise((resolve, reject) => {
       const img = new Image;
       img.onload = () => resolve(img);
       img.onerror = () => reject(new Error(`Unable to load file: ${this.name}`));

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -35,12 +35,8 @@ class FileAttachment {
     const url = await this.url();
     return new Promise((resolve, reject) => {
       const i = new Image;
-      try {
-        if (new URL(url).origin !== new URL(location).origin) {
-          i.crossOrigin = "anonymous";
-        }
-      } catch (e) {
-        // Relative paths, not urls.
+      if (new URL(url, document.baseURI).origin !== new URL(location).origin) {
+        i.crossOrigin = "anonymous";
       }
       i.onload = () => resolve(i);
       i.onerror = () => reject(new Error(`Unable to load file: ${this.name}`));

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -31,10 +31,13 @@ class FileAttachment {
   async image() {
     const url = await this.url();
     return new Promise((resolve, reject) => {
-      const img = new Image;
-      img.onload = () => resolve(img);
-      img.onerror = () => reject(new Error(`Unable to load file: ${this.name}`));
-      img.src = url;
+      const i = new Image;
+      if (new URL(url).origin !== new URL(location).origin) {
+        i.crossOrigin = "anonymous";
+      }
+      i.onload = () => resolve(i);
+      i.onerror = () => reject(new Error(`Unable to load file: ${this.name}`));
+      i.src = url;
     });
   }
 }

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -40,6 +40,6 @@ class FileAttachment {
   }
 }
 
-export default function ResolveFileAttachment(resolve) {
+export default function FileAttachments(resolve) {
   return (name) => new FileAttachment(resolve, name);
 }

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -35,8 +35,12 @@ class FileAttachment {
     const url = await this.url();
     return new Promise((resolve, reject) => {
       const i = new Image;
-      if (new URL(url).origin !== new URL(location).origin) {
-        i.crossOrigin = "anonymous";
+      try {
+        if (new URL(url).origin !== new URL(location).origin) {
+          i.crossOrigin = "anonymous";
+        }
+      } catch (e) {
+        // Relative paths, not urls.
       }
       i.onload = () => resolve(i);
       i.onerror = () => reject(new Error(`Unable to load file: ${this.name}`));

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-export {default as ResolveFileAttachment} from "./fileAttachment";
+export {default as FileAttachments} from "./fileAttachment";
 export {default as Library} from "./library";

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
+export {default as FileAttachment} from "./fileAttachment";
 export {default as Library} from "./library";

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-export {default as FileAttachment} from "./fileAttachment";
+export {default as ResolveFileAttachment} from "./fileAttachment";
 export {default as Library} from "./library";

--- a/src/library.js
+++ b/src/library.js
@@ -1,6 +1,5 @@
 import constant from "./constant";
 import DOM from "./dom/index";
-import FileAttachment from "./fileAttachment";
 import Files from "./files/index";
 import Generators from "./generators/index";
 import html from "./html";
@@ -18,7 +17,6 @@ export default function Library(resolver) {
   const require = requirer(resolver);
   Object.defineProperties(this, {
     DOM: {value: DOM, writable: true, enumerable: true},
-    FileAttachment: {value: constant(FileAttachment), writable: true, enumerable: true},
     Files: {value: Files, writable: true, enumerable: true},
     Generators: {value: Generators, writable: true, enumerable: true},
     html: {value: constant(html), writable: true, enumerable: true},

--- a/src/library.js
+++ b/src/library.js
@@ -1,5 +1,6 @@
 import constant from "./constant";
 import DOM from "./dom/index";
+import FileAttachment from "./fileAttachment";
 import Files from "./files/index";
 import Generators from "./generators/index";
 import html from "./html";
@@ -17,6 +18,7 @@ export default function Library(resolver) {
   const require = requirer(resolver);
   Object.defineProperties(this, {
     DOM: {value: DOM, writable: true, enumerable: true},
+    FileAttachment: {value: constant(FileAttachment), writable: true, enumerable: true},
     Files: {value: Files, writable: true, enumerable: true},
     Generators: {value: Generators, writable: true, enumerable: true},
     html: {value: constant(html), writable: true, enumerable: true},

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -4,6 +4,7 @@ import Library from "../src/library";
 test("new Library returns a library with the expected keys", async t => {
   t.deepEqual(Object.keys(new Library()).sort(), [
     "DOM",
+    "FileAttachment",
     "Files",
     "Generators",
     "Mutable",

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,10 +1,9 @@
 import { test } from "tap";
-import Library from "../src/library";
+import {Library, FileAttachment} from "../src";
 
 test("new Library returns a library with the expected keys", async t => {
   t.deepEqual(Object.keys(new Library()).sort(), [
     "DOM",
-    "FileAttachment",
     "Files",
     "Generators",
     "Mutable",
@@ -18,5 +17,11 @@ test("new Library returns a library with the expected keys", async t => {
     "tex",
     "width"
   ]);
+  t.end();
+});
+
+test("FileAttachment is exported by stdlib/index", t => {
+  t.equal(typeof FileAttachment, "function");
+  t.equal(FileAttachment.name, "FileAttachment");
   t.end();
 });

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,5 +1,5 @@
 import { test } from "tap";
-import {Library, ResolveFileAttachment} from "../src";
+import {Library, FileAttachments} from "../src";
 
 test("new Library returns a library with the expected keys", async t => {
   t.deepEqual(Object.keys(new Library()).sort(), [
@@ -20,8 +20,8 @@ test("new Library returns a library with the expected keys", async t => {
   t.end();
 });
 
-test("ResolveFileAttachment is exported by stdlib/index", t => {
-  t.equal(typeof ResolveFileAttachment, "function");
-  t.equal(ResolveFileAttachment.name, "ResolveFileAttachment");
+test("FileAttachments is exported by stdlib/index", t => {
+  t.equal(typeof FileAttachments, "function");
+  t.equal(FileAttachments.name, "FileAttachments");
   t.end();
 });

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -1,5 +1,5 @@
 import { test } from "tap";
-import {Library, FileAttachment} from "../src";
+import {Library, ResolveFileAttachment} from "../src";
 
 test("new Library returns a library with the expected keys", async t => {
   t.deepEqual(Object.keys(new Library()).sort(), [
@@ -20,8 +20,8 @@ test("new Library returns a library with the expected keys", async t => {
   t.end();
 });
 
-test("FileAttachment is exported by stdlib/index", t => {
-  t.equal(typeof FileAttachment, "function");
-  t.equal(FileAttachment.name, "FileAttachment");
+test("ResolveFileAttachment is exported by stdlib/index", t => {
+  t.equal(typeof ResolveFileAttachment, "function");
+  t.equal(ResolveFileAttachment.name, "ResolveFileAttachment");
   t.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -818,10 +818,10 @@ csstype@^2.2.0:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.6.tgz#c34f8226a94bbb10c32cc0d714afdf942291fc41"
   integrity sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg==
 
-d3-require@^1.2.0:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/d3-require/-/d3-require-1.2.3.tgz#65a1c2137e69c5c442f1ca2a04f72a3965124c16"
-  integrity sha512-zfat3WTZRZmh7jCrTIhg4zZvivA0DZvez8lZq0JwYG9aW8LcSUFO4eiPnL5F2MolHcLE8CLfEt06sPP8N7y3AQ==
+d3-require@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/d3-require/-/d3-require-1.2.4.tgz#59afc591d5089f99fecd8c45ef7539e1fee112b3"
+  integrity sha512-8UseEGCkBkBxIMouLMPONUBmU8DUPC1q12LARV1Lk/2Jwa32SVgmRfX8GdIeR06ZP+CG85YD3N13K2s14qCNyA==
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
... for use in UI, API (for downloads), and embeds.

- UI: resolve() function posts messages up to the parent frame to get signed URLs for private files.
- API: resolve() function is compiled with relative paths to downloaded files in the folder hierarchy.
- Embeds: resolve() function is compiled into the ES Modules, with absolute URLs of published files.

---

### Update

- Embeds: resolve() function is compiled into the generated ES Modules, with a map from name to absolute public (CloudFront), or private (currently CloudFront, future API) URLs.
- Downloads: resolve() function is compiled into the generated ES Modules, with a map from name to relative path on disk.
- Imports: Identical to Embeds, compiled with absolute URLs.
- UI: Passes in a `resolve()` function to this implementation that is capable of asking the parent frame (which may ask the server) for the URL for a given file.