### PR TITLE
File attachments image() "invalid URL" fix

### DIFF
--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -35,12 +35,8 @@ class FileAttachment {
     const url = await this.url();
     return new Promise((resolve, reject) => {
       const i = new Image;
-      try {
-        if (new URL(url).origin !== new URL(location).origin) {
-          i.crossOrigin = "anonymous";
-        }
-      } catch (e) {
-        // Relative paths, not urls.
+      if (new URL(url, document.baseURI).origin !== new URL(location).origin) {
+        i.crossOrigin = "anonymous";
       }
       i.onload = () => resolve(i);
       i.onerror = () => reject(new Error(`Unable to load file: ${this.name}`));

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -35,8 +35,12 @@ class FileAttachment {
     const url = await this.url();
     return new Promise((resolve, reject) => {
       const i = new Image;
-      if (new URL(url).origin !== new URL(location).origin) {
-        i.crossOrigin = "anonymous";
+      try {
+        if (new URL(url).origin !== new URL(location).origin) {
+          i.crossOrigin = "anonymous";
+        }
+      } catch (e) {
+        // Relative paths, not urls.
       }
       i.onload = () => resolve(i);
       i.onerror = () => reject(new Error(`Unable to load file: ${this.name}`));


### PR DESCRIPTION
Currently, calling `.image()` on a FileAttachment will fail if the attachment’s ".url()" returns a relative path.