### PR TITLE
File attachment URL strings (3.3.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observablehq/stdlib",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "license": "ISC",
   "main": "dist/stdlib.js",
   "module": "src/index.js",

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -7,7 +7,7 @@ async function remote_fetch(file) {
 class FileAttachment {
   constructor(url, name) {
     Object.defineProperties(this, {
-      _url: {value: url},
+      _url: {value: url + ""},
       name: {value: name, enumerable: true}
     });
   }

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -7,12 +7,12 @@ async function remote_fetch(file) {
 class FileAttachment {
   constructor(url, name) {
     Object.defineProperties(this, {
-      _url: {value: url + ""},
+      _url: {value: url},
       name: {value: name, enumerable: true}
     });
   }
   async url() {
-    return this._url;
+    return (await this._url) + "";
   }
   async blob() {
     return (await remote_fetch(this)).blob();

--- a/test/fileAttachments-test.js
+++ b/test/fileAttachments-test.js
@@ -6,3 +6,13 @@ test("FileAttachments is exported by stdlib", t => {
   t.equal(FileAttachments.name, "FileAttachments");
   t.end();
 });
+
+test("FileAttachment ensures that URLs are strings", async t => {
+  const fileAttachments = FileAttachments((name) =>
+    new URL(`https://example.com/${name}.js`)
+  );
+  const file = fileAttachments("filename");
+  t.equal(file.constructor.name, "FileAttachment");
+  t.equal(await file.url(), "https://example.com/filename.js");
+  t.end();
+});

--- a/test/fileAttachments-test.js
+++ b/test/fileAttachments-test.js
@@ -16,3 +16,13 @@ test("FileAttachment ensures that URLs are strings", async t => {
   t.equal(await file.url(), "https://example.com/filename.js");
   t.end();
 });
+
+test("FileAttachment works with Promises that resolve to URLs", async t => {
+  const fileAttachments = FileAttachments((name) =>
+    new Promise((resolve) => resolve(new URL(`https://example.com/${name}.js`)))
+  );
+  const file = fileAttachments("otherfile");
+  t.equal(file.constructor.name, "FileAttachment");
+  t.equal(await file.url(), "https://example.com/otherfile.js");
+  t.end();
+});

--- a/test/fileAttachments-test.js
+++ b/test/fileAttachments-test.js
@@ -18,8 +18,8 @@ test("FileAttachment ensures that URLs are strings", async t => {
 });
 
 test("FileAttachment works with Promises that resolve to URLs", async t => {
-  const fileAttachments = FileAttachments((name) =>
-    new Promise((resolve) => resolve(new URL(`https://example.com/${name}.js`)))
+  const fileAttachments = FileAttachments(async (name) =>
+    new URL(`https://example.com/${name}.js`)
   );
   const file = fileAttachments("otherfile");
   t.equal(file.constructor.name, "FileAttachment");


### PR DESCRIPTION
Ref: https://github.com/observablehq/notebook/issues/5002
Previously: https://github.com/observablehq/compiler/pull/24
(Private issues)

If a FileAttachment object is created with a `URL` object, ensure that it is coerced to a string.