### PR TITLE
Add recommended libraries

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
 
     runs-on: ${{ matrix.os }}
 

--- a/src/constant.js
+++ b/src/constant.js
@@ -1,5 +1,0 @@
-export default function(x) {
-  return function() {
-    return x;
-  };
-}

--- a/src/library.js
+++ b/src/library.js
@@ -1,5 +1,4 @@
 import {require as requireDefault} from "d3-require";
-import constant from "./constant.js";
 import DOM from "./dom/index.js";
 import Files from "./files/index.js";
 import {NoFileAttachments} from "./fileAttachment.js";
@@ -13,24 +12,39 @@ import resolve from "./resolve.js";
 import requirer from "./require.js";
 import svg from "./svg.js";
 import tex from "./tex.js";
+import vegalite from "./vegalite.js";
 import width from "./width.js";
 
 export default Object.assign(function Library(resolver) {
   const require = requirer(resolver);
-  Object.defineProperties(this, {
-    DOM: {value: DOM, writable: true, enumerable: true},
-    FileAttachment: {value: constant(NoFileAttachments), writable: true, enumerable: true},
-    Files: {value: Files, writable: true, enumerable: true},
-    Generators: {value: Generators, writable: true, enumerable: true},
-    html: {value: constant(html), writable: true, enumerable: true},
-    md: {value: md(require), writable: true, enumerable: true},
-    Mutable: {value: constant(Mutable), writable: true, enumerable: true},
-    now: {value: now, writable: true, enumerable: true},
-    Promises: {value: Promises, writable: true, enumerable: true},
-    require: {value: constant(require), writable: true, enumerable: true},
-    resolve: {value: constant(resolve), writable: true, enumerable: true},
-    svg: {value: constant(svg), writable: true, enumerable: true},
-    tex: {value: tex(require), writable: true, enumerable: true},
-    width: {value: width, writable: true, enumerable: true}
-  });
+  Object.defineProperties(this, properties({
+    DOM: () => DOM,
+    FileAttachment: () => NoFileAttachments,
+    Files: () => Files,
+    Generators: () => Generators,
+    Inputs: () => require("@observablehq/inputs@0.7.21/dist/inputs.umd.min.js"),
+    Mutable: () => Mutable,
+    Plot: () => require("@observablehq/plot@0.1.0/dist/plot.umd.min.js"),
+    Promises: () => Promises,
+    _: () => require("lodash@4.17.21/lodash.min.js"),
+    d3: () => require("d3@6.7.0/dist/d3.min.js"),
+    htl: () => require("htl@0.2.5/dist/htl.min.js"),
+    html: () => html,
+    md: md(require),
+    now: now,
+    require: () => require,
+    resolve: () => resolve,
+    svg: () => svg,
+    tex: tex(require),
+    vl: vegalite(require),
+    width: width
+  }));
 }, {resolve: requireDefault.resolve});
+
+function properties(values) {
+  return Object.fromEntries(Object.entries(values).map(property));
+}
+
+function property([key, value]) {
+  return [key, ({value, writable: true, enumerable: true})];
+}

--- a/src/library.js
+++ b/src/library.js
@@ -22,7 +22,7 @@ export default Object.assign(function Library(resolver) {
     FileAttachment: () => NoFileAttachments,
     Files: () => Files,
     Generators: () => Generators,
-    Inputs: () => require("@observablehq/inputs@0.7.21/dist/inputs.umd.min.js"),
+    Inputs: () => require("@observablehq/inputs@0.8.0/dist/inputs.umd.min.js"),
     Mutable: () => Mutable,
     Plot: () => require("@observablehq/plot@0.1.0/dist/plot.umd.min.js"),
     Promises: () => Promises,

--- a/src/promises/when.js
+++ b/src/promises/when.js
@@ -1,5 +1,3 @@
-import constant from "../constant.js";
-
 var timeouts = new Map;
 
 function timeout(now, time) {
@@ -16,7 +14,7 @@ function timeout(now, time) {
 
 export default function when(time, value) {
   var now;
-  return (now = timeouts.get(time = +time)) ? now.then(constant(value))
+  return (now = timeouts.get(time = +time)) ? now.then(() => value)
       : (now = Date.now()) >= time ? Promise.resolve(value)
-      : timeout(now, time).then(constant(value));
+      : timeout(now, time).then(() => value);
 }

--- a/src/vegalite.js
+++ b/src/vegalite.js
@@ -1,0 +1,10 @@
+export default function vl(require) {
+  return async () => {
+    const [vega, vegalite, api] = await Promise.all([
+      "vega@5.20.2/build/vega.min.js",
+      "vega-lite@5.1.0/build/vega-lite.min.js",
+      "vega-lite-api@5.0.0/build/vega-lite-api.min.js"
+    ].map(module => require(module)));
+    return api.register(vega, vegalite);
+  };
+}

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -7,8 +7,13 @@ test("new Library returns a library with the expected keys", async t => {
     "FileAttachment",
     "Files",
     "Generators",
+    "Inputs",
     "Mutable",
+    "Plot",
     "Promises",
+    "_",
+    "d3",
+    "htl",
     "html",
     "md",
     "now",
@@ -16,6 +21,7 @@ test("new Library returns a library with the expected keys", async t => {
     "resolve",
     "svg",
     "tex",
+    "vl",
     "width"
   ]);
   t.end();


### PR DESCRIPTION
This adds a handful of first-party and sanctioned third-party libraries to the Observable standard library for convenient access from notebooks. This set of libraries may grow over time based on demand. The current set is:

* `d3` - [D3.js](https://d3js.org)
* `htl` - Observable’s [Hypertext Literal](https://github.com/observablehq/htl)
* `Inputs` - [Observable Inputs](https://github.com/observablehq/inputs)
* `Plot` - [Observable Plot](https://github.com/observablehq/plot)
* `_` - [Lodash](https://lodash.com)
* `vl` - [Vega-Lite API](https://vega.github.io/vega-lite-api/)

In the last case, some additional code is required based on [this notebook](https://observablehq.com/@vega/vega-lite-api).

The trickiest part here is version pinning. I chose to hard-code the versions and paths in the standard library for stability and performance, and in particular to guarantee that duplicate versions of D3 and Hypertext Literal are not loaded: Observable Plot depends on D3, and Observable Inputs depends on Hypertext Literal. A consequence of this choice is that we’ll need to upgrade the Observable standard library explicitly, for everyone, when new versions of these libraries are released. However, when Observable supports version pinning natively in the future, we should be able to relax these requirements and give authors control over which version to use. In the meantime, notebook authors can require the libraries explicitly rather than depending on the standard library if they want to specify the version.