### PR TITLE
XLSX file attachments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
   "extends": "eslint:recommended",
   "parserOptions": {
     "sourceType": "module",
-    "ecmaVersion": 8
+    "ecmaVersion": 9
   },
   "env": {
     "browser": true,

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -63,9 +63,9 @@ class FileAttachment {
     const db = new SQL.Database(new Uint8Array(buffer));
     return new SQLiteDatabaseClient(db);
   }
-  async xlsx() {
+  async xlsx(options) {
     const [XLSX, buffer] = await Promise.all([xlsx(requireDefault), this.arrayBuffer()]);
-    return new XlsxWorkbook(await XLSX.read(buffer, {type: "buffer"}));
+    return new XlsxWorkbook(await XLSX.read(buffer, {cellDates: true, ...options, type: "buffer"}));
   }
 }
 

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -1,5 +1,6 @@
 import {require as requireDefault} from "d3-require";
 import sqlite, {SQLiteDatabaseClient} from "./sqlite.js";
+import xlsx, {XlsxWorkbook} from "./xlsx.js";
 
 async function remote_fetch(file) {
   const response = await fetch(await file.url());
@@ -61,6 +62,10 @@ class FileAttachment {
     const [SQL, buffer] = await Promise.all([sqlite(requireDefault), this.arrayBuffer()]);
     const db = new SQL.Database(new Uint8Array(buffer));
     return new SQLiteDatabaseClient(db);
+  }
+  async xlsx() {
+    const [XLSX, buffer] = await Promise.all([xlsx(requireDefault), this.arrayBuffer()]);
+    return new XlsxWorkbook(await XLSX.read(buffer, {type: "buffer"}));
   }
 }
 

--- a/src/xlsx.js
+++ b/src/xlsx.js
@@ -1,0 +1,20 @@
+let XLSX; // set lazily
+
+export default async function xslx(require) {
+  return XLSX = await require("xlsx@0.17.0/dist/xlsx.mini.min.js");
+}
+
+export class XlsxWorkbook {
+  constructor(workbook) {
+    Object.defineProperties(this, {
+      _: {value: workbook}
+    });
+  }
+  sheetNames() {
+    return this._.SheetNames.slice();
+  }
+  sheet(name, options) {
+    if (!Object.prototype.hasOwnProperty.call(this._.Sheets, name)) throw new Error("unknown sheet");
+    return XLSX.utils.sheet_to_json(this._.Sheets[name], options);
+  }
+}


### PR DESCRIPTION
This adds support for XLSX file attachments via [SheetJS](https://sheetjs.com). Similar to SQLiteDatabaseClient, I also chose to wrap the SheetJS API with a more convenient, minimal abstraction.

<img width="1445" alt="Screen Shot 2021-05-26 at 7 45 38 PM" src="https://user-images.githubusercontent.com/230541/119758179-f879d480-be5a-11eb-9096-a656061d16c2.png">

I chose not to expose SheetJS as a recommended library (for now). This step is not immediately needed to support XLSX file attachments, and there are multiple versions of SheetJS: we only need the “mini” version for XLSX, but we’d need the much bigger “full” version for XLS.
