### PR TITLE
Add promises.never as alternative to returning an unresolved promise.

### DIFF
--- a/src/promises/index.js
+++ b/src/promises/index.js
@@ -1,9 +1,11 @@
 import delay from "./delay.js";
+import never from "./never.js";
 import tick from "./tick.js";
 import when from "./when.js";
 
 export default {
   delay: delay,
+  never: never,
   tick: tick,
   when: when
 };

--- a/src/promises/never.js
+++ b/src/promises/never.js
@@ -1,0 +1,3 @@
+export default function() {
+  return new Promise(() => {});
+}


### PR DESCRIPTION
Add promises.never as alternative to returning an unresolved promise.

I often return new Promise(() => {}) to hold up the dataflow, but this is ugly.
Its not just me, see https://talk.observablehq.com/t/audio-worklet-example/5138
So this is a more readable alternative that I think belongs with the Promises
utilities.