### PR TITLE
Add support for ZIP file attachments.

### DIFF
--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -98,11 +98,11 @@ export class ZipArchive {
   file(path) {
     const object = this._.file(path);
     if (!object || object.dir) throw new Error("file not found");
-    return new ZipFile(object);
+    return new ZipArchiveEntry(object);
   }
 }
 
-class ZipFile extends AbstractFile {
+class ZipArchiveEntry extends AbstractFile {
   constructor(object) {
     super(object.name);
     Object.defineProperty(this, "_", {value: object});

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -92,7 +92,7 @@ export class ZipArchive {
   constructor(archive) {
     Object.defineProperty(this, "_", {value: archive});
   }
-  files() {
+  fileNames() {
     return Object.keys(this._.files);
   }
   file(path) {

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -91,9 +91,7 @@ export default function FileAttachments(resolve) {
 export class ZipArchive {
   constructor(archive) {
     Object.defineProperty(this, "_", {value: archive});
-  }
-  fileNames() {
-    return Object.keys(this._.files);
+    this.filenames = Object.keys(this._.files);
   }
   file(path) {
     const object = this._.file(path);

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -91,7 +91,7 @@ export default function FileAttachments(resolve) {
 export class ZipArchive {
   constructor(archive) {
     Object.defineProperty(this, "_", {value: archive});
-    this.filenames = Object.keys(this._.files);
+    this.filenames = Object.keys(archive.files).filter(name => !archive.files[name].dir);
   }
   file(path) {
     const object = this._.file(path += "");

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -1,5 +1,6 @@
 import {require as requireDefault} from "d3-require";
 import sqlite, {SQLiteDatabaseClient} from "./sqlite.js";
+import jszip from "./zip.js";
 
 async function remote_fetch(file) {
   const response = await fetch(await file.url());
@@ -14,15 +15,9 @@ async function dsv(file, delimiter, {array = false, typed = false} = {}) {
       : (array ? d3.csvParseRows : d3.csvParse))(text, typed && d3.autoType);
 }
 
-class FileAttachment {
-  constructor(url, name) {
-    Object.defineProperties(this, {
-      _url: {value: url},
-      name: {value: name, enumerable: true}
-    });
-  }
-  async url() {
-    return (await this._url) + "";
+class AbstractFile {
+  constructor(name) {
+    Object.defineProperty(this, "name", {value: name, enumerable: true});
   }
   async blob() {
     return (await remote_fetch(this)).blob();
@@ -62,6 +57,20 @@ class FileAttachment {
     const db = new SQL.Database(new Uint8Array(buffer));
     return new SQLiteDatabaseClient(db);
   }
+  async zip() {
+    const [JSZip, buffer] = await Promise.all([jszip(requireDefault), this.arrayBuffer()]);
+    return new ZipArchive(await JSZip.loadAsync(buffer));
+  }
+}
+
+class FileAttachment extends AbstractFile {
+  constructor(url, name) {
+    super(name);
+    Object.defineProperty(this, "_url", {value: url});
+  }
+  async url() {
+    return (await this._url) + "";
+  }
 }
 
 export function NoFileAttachments(name) {
@@ -77,4 +86,41 @@ export default function FileAttachments(resolve) {
     },
     {prototype: FileAttachment.prototype} // instanceof
   );
+}
+
+export class ZipArchive {
+  constructor(archive) {
+    Object.defineProperty(this, "_", {value: archive});
+  }
+  files() {
+    return Object.keys(this._.files);
+  }
+  file(path) {
+    const object = this._.file(path);
+    if (!object || object.dir) throw new Error("file not found");
+    return new ZipFile(object);
+  }
+}
+
+class ZipFile extends AbstractFile {
+  constructor(object) {
+    super(object.name);
+    Object.defineProperty(this, "_", {value: object});
+    Object.defineProperty(this, "_url", {writable: true});
+  }
+  async url() {
+    return this._url || (this._url = this.blob().then(URL.createObjectURL));
+  }
+  async blob() {
+    return this._.async("blob");
+  }
+  async arrayBuffer() {
+    return this._.async("arraybuffer");
+  }
+  async text() {
+    return this._.async("text");
+  }
+  async json() {
+    return JSON.parse(await this.text());
+  }
 }

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -94,8 +94,8 @@ export class ZipArchive {
     this.filenames = Object.keys(this._.files);
   }
   file(path) {
-    const object = this._.file(path);
-    if (!object || object.dir) throw new Error("file not found");
+    const object = this._.file(path += "");
+    if (!object || object.dir) throw new Error(`file not found: ${path}`);
     return new ZipArchiveEntry(object);
   }
 }

--- a/src/zip.js
+++ b/src/zip.js
@@ -1,0 +1,3 @@
+export default async function jszip(require) {
+  return await require("jszip@3.6.0/dist/jszip.min.js");
+}


### PR DESCRIPTION
Adds *fileAttachment*.zip which returns a promise to a ZipArchive. The ZipArchive exposes an *archive*.fileNames() method which returns the array of file names, and an *archive*.file(*name*) method which returns a FileAttachment-like object. So, to load a CSV file in a ZIP file, you can now say:

```js
archive = FileAttachment("ACS_14_5YR_B01003.zip").zip()
```
```js
data = archive.file("ACS_14_5YR_B01003_with_ann.csv").csv({typed: true})
```

As with XLSX #215, I’ve decided not to expose JSZip as a recommended library, and instead wrap it with a more minimal abstraction that feels more Observable-ish.

<img width="1273" alt="Screen Shot 2021-06-01 at 6 47 28 PM" src="https://user-images.githubusercontent.com/230541/120411777-34ed7a80-c30a-11eb-8f2a-df143e91d868.png">
