### PR TITLE
Add Apache Arrow as a recommended library and supported file attachment

### DIFF
--- a/bin/resolve-dependencies
+++ b/bin/resolve-dependencies
@@ -60,6 +60,10 @@ const fetch = require("node-fetch");
     const package = await resolve("vega-lite-api");
     console.log(`export const vegaliteApi = dependency("${package.name}", "${package.version}", "${package.export}");`);
   }
+  {
+    const package = await resolve("apache-arrow@4");
+    console.log(`export const arrow = dependency("${package.name}", "${package.version}", "${package.export}");`);
+  }
 })();
 
 async function resolve(specifier) {

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -13,3 +13,4 @@ export const sql = dependency("sql.js", "1.5.0", "dist/sql-wasm.js");
 export const vega = dependency("vega", "5.20.2", "build/vega.min.js");
 export const vegalite = dependency("vega-lite", "5.1.0", "build/vega-lite.min.js");
 export const vegaliteApi = dependency("vega-lite-api", "5.0.0", "build/vega-lite-api.min.js");
+export const arrow = dependency("apache-arrow", "4.0.1", "Arrow.es2015.min.js");

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -1,5 +1,5 @@
 import {require as requireDefault} from "d3-require";
-import {d3Dsv} from "./dependencies.js";
+import {arrow, d3Dsv} from "./dependencies.js";
 import {SQLiteDatabaseClient} from "./sqlite.js";
 import jszip from "./zip.js";
 
@@ -52,6 +52,10 @@ class AbstractFile {
       i.onerror = () => reject(new Error(`Unable to load file: ${this.name}`));
       i.src = url;
     });
+  }
+  async arrow() {
+    const [Arrow, response] = await Promise.all([requireDefault(arrow.resolve()), remote_fetch(this)]);
+    return Arrow.Table.from(response);
   }
   async sqlite() {
     return SQLiteDatabaseClient.open(remote_fetch(this));

--- a/src/library.js
+++ b/src/library.js
@@ -15,12 +15,13 @@ import svg from "./svg.js";
 import tex from "./tex.js";
 import vegalite from "./vegalite.js";
 import width from "./width.js";
-import {d3, graphviz, htl, inputs, lodash, plot} from "./dependencies.js";
+import {arrow, d3, graphviz, htl, inputs, lodash, plot} from "./dependencies.js";
 
 export default Object.assign(function Library(resolver) {
   const require = requirer(resolver);
   Object.defineProperties(this, properties({
     FileAttachment: () => NoFileAttachments,
+    Arrow: () => require(arrow.resolve()),
     Inputs: () => require(inputs.resolve()),
     Mutable: () => Mutable,
     Plot: () => require(plot.resolve()),

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -3,6 +3,7 @@ import {Library} from "../src/index.js";
 
 test("new Library returns a library with the expected keys", async t => {
   t.deepEqual(Object.keys(new Library()).sort(), [
+    "Arrow",
     "DOM",
     "FileAttachment",
     "Files",


### PR DESCRIPTION
Apache Arrow is exposed as `Arrow` in the standard library, and _fileAttachment_.arrow() returns a Promise to an Arrow.Table.

<img width="1274" alt="Screen Shot 2021-06-02 at 3 56 19 PM" src="https://user-images.githubusercontent.com/230541/120562361-1abfa500-c3bb-11eb-92f6-a0ac25e551fa.png">
