### PR TITLE
resolve jszip

### DIFF
--- a/bin/resolve-dependencies
+++ b/bin/resolve-dependencies
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 const fetch = require("node-fetch");
+const extensionRe = /\.[^/]*$/;
+const mains = ["unpkg", "jsdelivr", "browser", "main"];
 
 (async () => {
   console.log(`import dependency from "./dependency.js";`);
@@ -41,6 +43,10 @@ const fetch = require("node-fetch");
     console.log(`export const htl = dependency("${package.name}", "${package.version}", "${package.export}");`);
   }
   {
+    const package = await resolve("jszip");
+    console.log(`export const jszip = dependency("${package.name}", "${package.version}", "dist/jszip.min.js");`);
+  }
+  {
     const package = await resolve("marked@0.3.12");
     console.log(`export const marked = dependency("${package.name}", "${package.version}", "marked.min.js");`);
   }
@@ -72,6 +78,17 @@ async function resolve(specifier) {
   return {
     name: package.name,
     version: package.version,
-    export: (package.unpkg || package.jsdelivr || package.browser || package.main).replace(/^\.\//, "")
+    export: main(package)
   };
+}
+
+// https://github.com/d3/d3-require/blob/4056a786912e9335a86b41c2b1cdfa392bd14289/src/index.js#L20-L27
+function main(meta) {
+  for (const key of mains) {
+    const value = meta[key];
+    if (typeof value === "string") {
+      return (extensionRe.test(value) ? value : `${value}.js`).replace(/^\.\//, "");
+    }
+  }
+  return "index.js";
 }

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -8,6 +8,7 @@ export const highlight = dependency("@observablehq/highlight.js", "2.0.0", "high
 export const katex = dependency("@observablehq/katex", "0.11.1", "dist/katex.min.js");
 export const lodash = dependency("lodash", "4.17.21", "lodash.min.js");
 export const htl = dependency("htl", "0.2.5", "dist/htl.min.js");
+export const jszip = dependency("jszip", "3.7.0", "dist/jszip.min.js");
 export const marked = dependency("marked", "0.3.12", "marked.min.js");
 export const sql = dependency("sql.js", "1.5.0", "dist/sql-wasm.js");
 export const vega = dependency("vega", "5.20.2", "build/vega.min.js");

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -1,7 +1,6 @@
 import {require as requireDefault} from "d3-require";
-import {arrow, d3Dsv} from "./dependencies.js";
+import {arrow, d3Dsv, jszip} from "./dependencies.js";
 import {SQLiteDatabaseClient} from "./sqlite.js";
-import jszip from "./zip.js";
 
 async function remote_fetch(file) {
   const response = await fetch(await file.url());
@@ -61,7 +60,7 @@ class AbstractFile {
     return SQLiteDatabaseClient.open(remote_fetch(this));
   }
   async zip() {
-    const [JSZip, buffer] = await Promise.all([jszip(requireDefault), this.arrayBuffer()]);
+    const [JSZip, buffer] = await Promise.all([requireDefault(jszip.resolve()), this.arrayBuffer()]);
     return new ZipArchive(await JSZip.loadAsync(buffer));
   }
 }

--- a/src/zip.js
+++ b/src/zip.js
@@ -1,3 +1,0 @@
-export default async function jszip(require) {
-  return await require("jszip@3.6.0/dist/jszip.min.js");
-}


### PR DESCRIPTION
I missed this when rebasing #222. This also upgrades JSZip from 3.6.0 to 3.7.0 which you can see here:

https://github.com/Stuk/jszip/compare/v3.6.0...e5b3f0ddaa8182cd6ea253e97f678b9f36d0d8ac

The only change appears to be a security fix for weirdly-named files which I do not think applies in our usage.