### PR TITLE
inline d3-dsv

### DIFF
--- a/bin/resolve-dependencies
+++ b/bin/resolve-dependencies
@@ -11,10 +11,6 @@ const mains = ["unpkg", "jsdelivr", "browser", "main"];
     console.log(`export const d3 = dependency("${package.name}", "${package.version}", "${package.export}");`);
   }
   {
-    const package = await resolve("d3-dsv");
-    console.log(`export const d3Dsv = dependency("${package.name}", "${package.version}", "${package.export}");`);
-  }
-  {
     const package = await resolve("@observablehq/inputs");
     console.log(`export const inputs = dependency("${package.name}", "${package.version}", "${package.export}");`);
   }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dist/**/*.js"
   ],
   "dependencies": {
+    "d3-dsv": "^2.0.0",
     "d3-require": "^1.2.4"
   },
   "devDependencies": {

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -1,6 +1,5 @@
 import dependency from "./dependency.js";
 export const d3 = dependency("d3", "7.0.1", "dist/d3.min.js");
-export const d3Dsv = dependency("d3-dsv", "3.0.1", "dist/d3-dsv.min.js");
 export const inputs = dependency("@observablehq/inputs", "0.9.0", "dist/inputs.min.js");
 export const plot = dependency("@observablehq/plot", "0.2.0", "dist/plot.umd.min.js");
 export const graphviz = dependency("@observablehq/graphviz", "0.2.1", "dist/graphviz.min.js");

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -1,5 +1,6 @@
+import {autoType, csvParse, csvParseRows, tsvParse, tsvParseRows} from "d3-dsv";
 import {require as requireDefault} from "d3-require";
-import {arrow, d3Dsv, jszip} from "./dependencies.js";
+import {arrow, jszip} from "./dependencies.js";
 import {SQLiteDatabaseClient} from "./sqlite.js";
 
 async function remote_fetch(file) {
@@ -9,10 +10,10 @@ async function remote_fetch(file) {
 }
 
 async function dsv(file, delimiter, {array = false, typed = false} = {}) {
-  const [text, d3] = await Promise.all([file.text(), requireDefault(d3Dsv.resolve())]);
+  const text = await file.text();
   return (delimiter === "\t"
-      ? (array ? d3.tsvParseRows : d3.tsvParse)
-      : (array ? d3.csvParseRows : d3.csvParse))(text, typed && d3.autoType);
+      ? (array ? tsvParseRows : tsvParse)
+      : (array ? csvParseRows : csvParse))(text, typed && autoType);
 }
 
 class AbstractFile {

--- a/yarn.lock
+++ b/yarn.lock
@@ -689,7 +689,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.20.0:
+commander@2, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -786,6 +786,15 @@ csstype@^3.0.2:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.6.tgz#865d0b5833d7d8d40f4e5b8a6d76aea3de4725ef"
   integrity sha512-+ZAmfyWMT7TiIlzdqJgjMb7S4f1beorDbWbsocyK4RaiqA5RTX3K14bnBWmmA9QEM0gRdsjyyrEmcyga8Zsxmw==
+
+d3-dsv@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-2.0.0.tgz#b37b194b6df42da513a120d913ad1be22b5fe7c5"
+  integrity sha512-E+Pn8UJYx9mViuIUkoc93gJGGYut6mSDKy2+XaPwccwkRGlR+LO97L2VCCRjQivTwLHkSnAJG7yo00BWY6QM+w==
+  dependencies:
+    commander "2"
+    iconv-lite "0.4"
+    rw "1"
 
 d3-require@^1.2.4:
   version "1.2.4"
@@ -1306,6 +1315,13 @@ husky@^4.3.8:
     please-upgrade-node "^3.2.0"
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
+
+iconv-lite@0.4:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -2331,6 +2347,11 @@ rollup@^2.37.1:
   optionalDependencies:
     fsevents "~2.1.2"
 
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
+  integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
@@ -2341,7 +2362,7 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==


### PR DESCRIPTION
This inlines the d3-dsv dependency which is needed to support CSV file attachments. This adds 1,019 bytes to the gzipped file size (from 6,263 to 7,282), which should be negligible, and avoids an additional server roundtrip before loading a CSV file.