### PR TITLE
add xml support for file attachments

### DIFF
--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -64,8 +64,11 @@ class AbstractFile {
     const [JSZip, buffer] = await Promise.all([requireDefault(jszip.resolve()), this.arrayBuffer()]);
     return new ZipArchive(await JSZip.loadAsync(buffer));
   }
-  async xml() {
-    return (new DOMParser).parseFromString(await (await remote_fetch(this)).text(), "application/xml");
+  async xml(mimeType = "application/xml") {
+    return (new DOMParser).parseFromString(await this.text(), mimeType);
+  }
+  async html() {
+    return this.xml("text/html");
   }
 }
 


### PR DESCRIPTION
This adds xml support to File Attachments by feeding .text() through DOMParser.
Suggested by [Andreas Plesch](https://github.com/andreasplesch) [here](https://github.com/andreasplesch/stdlib/commit/ec384fa25a00e8d468b32800ff6a84a6080ee704)