### PR TITLE
add attributes to image() as options

### DIFF
--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -46,10 +46,10 @@ export class AbstractFile {
     const url = await this.url();
     return new Promise((resolve, reject) => {
       const i = new Image();
-      Object.assign(i, props);
       if (new URL(url, document.baseURI).origin !== new URL(location).origin) {
         i.crossOrigin = "anonymous";
       }
+      Object.assign(i, props);
       i.onload = () => resolve(i);
       i.onerror = () => reject(new Error(`Unable to load file: ${this.name}`));
       i.src = url;


### PR DESCRIPTION
Reference #231

This doesn't address all of the image options, but starts by addressing the most common requests... width, height, alt and title. 

Example:

<img width="864" alt="Screen Shot 2021-10-17 at 5 12 23 PM" src="https://user-images.githubusercontent.com/10869236/137650136-3c2825d1-42e4-4b2e-a5e9-b5ecba2c29f1.png">

