### PR TITLE
Add SQL tag function and dialect property to SQLiteDatabaseClient

### DIFF
--- a/src/sqlite.js
+++ b/src/sqlite.js
@@ -39,7 +39,13 @@ export class SQLiteDatabaseClient {
       element("tbody", rows.map(r => element("tr", columns.map(c => element("td", [text(r[c])])))))
     ]);
   }
+  async sql(strings, ...args) {
+    return this.query(strings.join("?"), args);
+  }
 }
+Object.defineProperty(SQLiteDatabaseClient.prototype, "dialect", {
+  value: "sqlite"
+});
 
 function load(source) {
   return typeof source === "string" ? fetch(source).then(load)


### PR DESCRIPTION
This change brings SQLiteDatabaseClient up to parity with the other DatabaseClient implementations in Observable.

Tested locally:


<img width="1220" alt="Screen Shot 2021-10-26 at 16 31 19" src="https://user-images.githubusercontent.com/6464196/138956312-85b12e73-c66d-4495-849c-91f10e033d7c.png">

