### PR TITLE
SQLiteDatabaseClient.queryTag

### DIFF
--- a/src/sqlite.js
+++ b/src/sqlite.js
@@ -39,8 +39,11 @@ export class SQLiteDatabaseClient {
       element("tbody", rows.map(r => element("tr", columns.map(c => element("td", [text(r[c])])))))
     ]);
   }
-  async sql(strings, ...args) {
-    return this.query(strings.join("?"), args);
+  async sql() {
+    return this.query(...this.queryTag.apply(this, arguments));
+  }
+  queryTag(strings, ...params) {
+    return [strings.join("?"), params];
   }
 }
 Object.defineProperty(SQLiteDatabaseClient.prototype, "dialect", {


### PR DESCRIPTION
Partially addresses https://github.com/observablehq/observablehq/issues/6557 and https://github.com/observablehq/observablehq/issues/5368

Along with https://github.com/observablehq/stdlib/pull/283, this PR will make SQLiteDatabaseClient work with the Table cell.