### PR TITLE
Split schema function into describeSchema and describeTable

### DIFF
--- a/src/sqlite.js
+++ b/src/sqlite.js
@@ -105,7 +105,10 @@ function sqliteType({type, notnull}) {
         : "other";
       break;
   }
-  return {type: notnull ? t : [t, "null"]};
+  return {
+    type: notnull ? t : [t, "null"],
+    databaseType: type
+  };
 }
 
 function load(source) {


### PR DESCRIPTION
[Wiltse's PR](https://github.com/observablehq/observablehq/pull/6682) updates the DatabaseClient schema API to contain two separate functions for fetching the schema information: describeSchema and describeTable. We'll want SQLiteDatabaseClient to be consistent with that as well.

This is still in draft since Wiltse's PR isn't merged yet and the API is still subject to change.