### PR TITLE
allow Library.require override

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,7 +849,7 @@ tex.options({displayMode: true})`E = mc^2`
 
 <a href="#require" name="require">#</a> <b>require</b>(<i>names…</i>) [<>](https://github.com/d3/d3-require/blob/master/index.js "Source")
 
-Returns a promise of the [asynchronous module definition](https://github.com/amdjs/amdjs-api/blob/master/AMD.md) (AMD) with the specified *names*, loaded from [jsDelivr](https://jsdelivr.com/). Each module *name* can be a package (or scoped package) name optionally followed by the at sign (`@`) and a semver range. For example, to load [d3-array](https://github.com/d3/d3-array):
+Returns a promise of the [asynchronous module definition](https://github.com/amdjs/amdjs-api/blob/master/AMD.md) (AMD) with the specified *names*, loaded from npm. Each module *name* can be a package (or scoped package) name optionally followed by the at sign (`@`) and a semver range. For example, to load [d3-array](https://github.com/d3/d3-array):
 
 ```js
 d3 = require("d3-array")

--- a/src/dependency.js
+++ b/src/dependency.js
@@ -1,7 +1,7 @@
 export default function dependency(name, version, main) {
   return {
     resolve(path = main) {
-      return `https://cdn.jsdelivr.net/npm/${name}@${version}/${path}`;
+      return `${name}@${version}/${path}`;
     }
   };
 }

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -1,6 +1,6 @@
 import {autoType, csvParse, csvParseRows, tsvParse, tsvParseRows} from "d3-dsv";
-import {require as requireDefault} from "d3-require";
 import {arrow, jszip, exceljs} from "./dependencies.js";
+import {requireDefault} from "./require.js";
 import {SQLiteDatabaseClient} from "./sqlite.js";
 import {Workbook} from "./xlsx.js";
 

--- a/src/library.js
+++ b/src/library.js
@@ -1,4 +1,3 @@
-import {require as requireDefault} from "d3-require";
 import DOM from "./dom/index.js";
 import Files from "./files/index.js";
 import {AbstractFile, FileAttachment, NoFileAttachments} from "./fileAttachment.js";
@@ -11,7 +10,7 @@ import Mutable from "./mutable.js";
 import now from "./now.js";
 import Promises from "./promises/index.js";
 import resolve from "./resolve.js";
-import requirer from "./require.js";
+import requirer, {requireDefault, setDefaultRequire} from "./require.js";
 import SQLite, {SQLiteDatabaseClient} from "./sqlite.js";
 import svg from "./svg.js";
 import tex from "./tex.js";
@@ -74,7 +73,11 @@ export default Object.assign(function Library(resolver) {
     Generators,
     Promises
   }));
-}, {resolve: requireDefault.resolve});
+}, {
+  get resolve() { return requireDefault.resolve; },
+  get require() { return requireDefault; },
+  set require(r) { setDefaultRequire(r); }
+});
 
 function properties(values) {
   return Object.fromEntries(Object.entries(values).map(property));

--- a/src/require.js
+++ b/src/require.js
@@ -1,4 +1,10 @@
-import {require as requireDefault, requireFrom} from "d3-require";
+import {require as initialRequire} from "d3-require";
+
+export let requireDefault = initialRequire;
+
+export function setDefaultRequire(require) {
+  requireDefault = require;
+}
 
 export default function(resolve) {
   return resolve == null ? requireDefault : requireFrom(resolve);

--- a/src/sqlite.js
+++ b/src/sqlite.js
@@ -1,5 +1,5 @@
-import {require as requireDefault} from "d3-require";
-import {sql} from "./dependencies";
+import {sql} from "./dependencies.js";
+import {requireDefault} from "./require.js";
 
 export default async function sqlite(require) {
   const init = await require(sql.resolve());

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,9 +1002,9 @@ d3-dsv@^2.0.0:
     rw "1"
 
 d3-require@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/d3-require/-/d3-require-1.2.4.tgz#59afc591d5089f99fecd8c45ef7539e1fee112b3"
-  integrity sha512-8UseEGCkBkBxIMouLMPONUBmU8DUPC1q12LARV1Lk/2Jwa32SVgmRfX8GdIeR06ZP+CG85YD3N13K2s14qCNyA==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/d3-require/-/d3-require-1.3.0.tgz#2b97f5e2ebcb64ac0c63c11f30056aea1c74f0ec"
+  integrity sha512-XaNc2azaAwXhGjmCMtxlD+AowpMfLimVsAoTMpqrvb8CWoA4QqyV12mc4Ue6KSoDvfuS831tsumfhDYxGd4FGA==
 
 dashdash@^1.12.0:
   version "1.14.1"


### PR DESCRIPTION
This PR allows the user to change the require implementation by assigning to Library.require.

Originally, I intended this to be local to the Library instance (hence the _resolve_ argument to the Library constructor). However, there are a number of places where we want to require stuff statically, such as within the AbstractFile class definition. Therefore it seems unavoidable to have only a single definition of require. (Eventually we want to move everything to dynamic ES module imports anyway…)