### PR TITLE
treat main as the default schema

### DIFF
--- a/src/sqlite.js
+++ b/src/sqlite.js
@@ -29,7 +29,7 @@ export class SQLiteDatabaseClient {
     ]);
   }
   async describeTables({schema} = {}) {
-    return this.query(`SELECT schema, name FROM pragma_table_list() WHERE type = 'table'${schema == null ? "" : ` AND schema = ?`} AND name NOT LIKE 'sqlite_%'`, schema == null ? [] : [schema]);
+    return this.query(`SELECT NULLIF(schema, 'main') AS schema, name FROM pragma_table_list() WHERE type = 'table'${schema == null ? "" : ` AND schema = ?`} AND name NOT LIKE 'sqlite_%'`, schema == null ? [] : [schema]);
   }
   async describeColumns({schema, table} = {}) {
     if (table == null) throw new Error(`missing table`);


### PR DESCRIPTION
Per https://sqlite.org/lang_attach.html

> The schema-names 'main' and 'temp' refer to the main database and the database used for temporary tables. The main and temp databases cannot be attached or detached. … If the name of the table is unique across all attached databases and the main and temp databases, then the schema-name prefix is not required. If two or more tables in different databases have the same name and the schema-name prefix is not used on a table reference, then the table chosen is the one in the database that was least recently attached.