### PR TITLE
Node 12 compatibility

### DIFF
--- a/src/table.mjs
+++ b/src/table.mjs
@@ -80,7 +80,7 @@ async function* accumulateQuery(queryRequest) {
   if (
     from.table === null ||
     select.columns === null ||
-    select.columns?.length === 0
+    (select.columns && select.columns.length === 0)
   )
     return;
   const columns = select.columns.map((c) => `t.${escaper(c)}`);
@@ -97,7 +97,7 @@ async function* accumulateQuery(queryRequest) {
   }
   if (slice.to !== null || slice.from !== null) {
     appendSql(
-      `\nLIMIT ${slice.to !== null ? slice.to - (slice.from ?? 0) : 1e9}`,
+      `\nLIMIT ${slice.to !== null ? slice.to - (slice.from || 0) : 1e9}`,
       args
     );
   }


### PR DESCRIPTION
Remove the nullish coalescing operator and optional chaining in `makeQueryTemplate`, which seem to be unavailable in Node 12 (see [runtime PR](https://github.com/observablehq/runtime/pull/336)).

Since it seems like the runtime expects compatibility with Node 12, should we add a Node 12 test to stdlib as well?