### PR TITLE
Add __table function and unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "dist/**/*.js"
   ],
   "dependencies": {
+    "d3-array": "^3.2.0",
     "d3-dsv": "^2.0.0",
     "d3-require": "^1.3.0"
   },

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,3 +1,3 @@
 export {default as FileAttachments, AbstractFile} from "./fileAttachment.mjs";
 export {default as Library} from "./library.mjs";
-export {makeQueryTemplate, isDatabaseClient} from "./table.mjs";
+export {makeQueryTemplate, isDataArray, isDatabaseClient} from "./table.mjs";

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,3 +1,3 @@
 export {default as FileAttachments, AbstractFile} from "./fileAttachment.mjs";
 export {default as Library} from "./library.mjs";
-export {makeQueryTemplate} from "./table.mjs";
+export {makeQueryTemplate, isDatabaseClient} from "./table.mjs";

--- a/src/table.mjs
+++ b/src/table.mjs
@@ -1,13 +1,26 @@
 import {ascending, descending, reverse} from "d3-array";
 
+export function isTypedArray(value) {
+  return (
+    value instanceof Int8Array ||
+    value instanceof Int16Array ||
+    value instanceof Int32Array ||
+    value instanceof Uint8Array ||
+    value instanceof Uint8ClampedArray ||
+    value instanceof Uint16Array ||
+    value instanceof Uint32Array ||
+    value instanceof Float32Array
+  );
+}
+
 export const __query = Object.assign(
   // This function is used by table cells.
   async (source, operations, invalidation) => {
     // For cells whose data source is an in-memory table, we use JavaScript to
     // apply the table cell operations, instead of composing a SQL query.
-    // TODO Do we need to do a more comprehensive isArray check, like the one
-    // we do in the worker?
-    if (Array.isArray(source)) return __table(source, operations);
+    // TODO Do we need to port over all the logic from canDisplayTable, or is
+    // this sufficient?
+    if (Array.isArray(source) || isTypedArray(source)) return __table(source, operations);
     const args = makeQueryTemplate(await source, operations);
     if (!args) return null; // the empty state
     return evaluateQuery(await source, args, invalidation);

--- a/src/table.mjs
+++ b/src/table.mjs
@@ -277,7 +277,12 @@ export function __table(source, operations) {
     switch (type) {
       case "eq": {
         const [value] = values;
-        source = source.filter((d) => d[column] === value);
+        if (value instanceof Date) {
+          const time = +value; // compare as primitive
+          source = source.filter((d) => +d[column] === time);
+        } else {
+          source = source.filter((d) => d[column] === value);
+        }
         break;
       }
       case "ne": {
@@ -300,12 +305,12 @@ export function __table(source, operations) {
         break;
       }
       case "in": {
-        const set = new Set(values);
+        const set = new Set(values); // TODO support dates?
         source = source.filter((d) => set.has(d[column]));
         break;
       }
       case "nin": {
-        const set = new Set(values);
+        const set = new Set(values); // TODO support dates?
         source = source.filter((d) => !set.has(d[column]));
         break;
       }
@@ -322,9 +327,19 @@ export function __table(source, operations) {
         source = source.filter((d) => d[column] < value);
         break;
       }
+      case "lte": {
+        const [value] = values;
+        source = source.filter((d) => d[column] <= value);
+        break;
+      }
       case "gt": {
         const [value] = values;
         source = source.filter((d) => d[column] > value);
+        break;
+      }
+      case "gte": {
+        const [value] = values;
+        source = source.filter((d) => d[column] >= value);
         break;
       }
       default:

--- a/src/table.mjs
+++ b/src/table.mjs
@@ -142,8 +142,6 @@ function isTypedArray(value) {
 export const __query = Object.assign(
   async (source, operations, invalidation) => {
     source = await source;
-    // For cells whose data source is an in-memory table, we use JavaScript to
-    // apply the table cell operations, instead of composing a SQL query.
     if (isDatabaseClient(source)) return evaluateQuery(source, makeQueryTemplate(operations, source), invalidation);
     if (isDataArray(source)) return __table(source, operations);
     if (!source) throw new Error("missing source");
@@ -372,7 +370,8 @@ function likeOperand(operand) {
   return {...operand, value: `%${operand.value}%`};
 }
 
-// This function applies table cell operations to an in-memory table (array of objects).
+// This function applies table cell operations to an in-memory table (array of
+// objects); it should be equivalent to the corresponding SQL query.
 export function __table(source, operations) {
   if (arrayIsPrimitive(source)) source = Array.from(source, (value) => ({value}));
   const input = source;

--- a/src/table.mjs
+++ b/src/table.mjs
@@ -144,8 +144,8 @@ export const __query = Object.assign(
     source = await source;
     if (isDatabaseClient(source)) return evaluateQuery(source, makeQueryTemplate(operations, source), invalidation);
     if (isDataArray(source)) return __table(source, operations);
-    if (!source) throw new Error("missing source");
-    throw new Error("invalid source");
+    if (!source) throw new Error("missing data source");
+    throw new Error("invalid data source");
   },
   {
     sql(source, invalidation) {
@@ -157,7 +157,7 @@ export const __query = Object.assign(
 );
 
 async function evaluateQuery(source, args, invalidation) {
-  if (!source) throw new Error("missing source");
+  if (!source) throw new Error("missing data source");
 
   // If this DatabaseClient supports abort and streaming, use that.
   if (typeof source.queryTag === "function") {

--- a/test/table-test.mjs
+++ b/test/table-test.mjs
@@ -38,15 +38,15 @@ const baseOperations = {
 describe("makeQueryTemplate", () => {
   it("makeQueryTemplate null table", () => {
     const source = {};
-    assert.strictEqual(makeQueryTemplate(source, EMPTY_TABLE_DATA.operations), undefined);
+    assert.strictEqual(makeQueryTemplate(EMPTY_TABLE_DATA.operations, source), undefined);
   });
   
   it("makeQueryTemplate no selected columns", () => {
     const source = {name: "db", dialect: "postgres"};
     const operationsColumnsNull = {...baseOperations, select: {columns: null}};
-    assert.strictEqual(makeQueryTemplate(source, operationsColumnsNull), undefined);
+    assert.strictEqual(makeQueryTemplate(operationsColumnsNull, source), undefined);
     const operationsColumnsEmpty = {...baseOperations, select: {columns: []}};
-    assert.strictEqual(makeQueryTemplate(source, operationsColumnsEmpty), undefined);
+    assert.strictEqual(makeQueryTemplate(operationsColumnsEmpty, source), undefined);
   });
   
   it("makeQueryTemplate invalid filter operation", () => {
@@ -78,7 +78,7 @@ describe("makeQueryTemplate", () => {
         ...baseOperations,
         filter: [filter]
       };
-      assert.throws(() => makeQueryTemplate(source, operations), /Invalid filter operation/);
+      assert.throws(() => makeQueryTemplate(operations, source), /Invalid filter operation/);
     });
   });
   
@@ -97,7 +97,7 @@ describe("makeQueryTemplate", () => {
       ]
     };
   
-    const [parts, ...params] = makeQueryTemplate(source, operations);
+    const [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nWHERE t.col1 = ?");
     assert.deepStrictEqual(params, ["val1"]);
   });
@@ -126,7 +126,7 @@ describe("makeQueryTemplate", () => {
       ]
     };
   
-    const [parts, ...params] = makeQueryTemplate(source, operations);
+    const [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nWHERE t.col1 IN (?,?,?)\nAND t.col1 NOT IN (?)");
     assert.deepStrictEqual(params, ["val1", "val2", "val3", "val4"]);
   });
@@ -140,7 +140,7 @@ describe("makeQueryTemplate", () => {
       }
     };
   
-    const [parts, ...params] = makeQueryTemplate(source, operations);
+    const [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2,t.col3 FROM table1 t");
     assert.deepStrictEqual(params, []);
   });
@@ -155,7 +155,7 @@ describe("makeQueryTemplate", () => {
       ]
     };
   
-    const [parts, ...params] = makeQueryTemplate(source, operations);
+    const [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nORDER BY t.col1 ASC, t.col2 DESC");
     assert.deepStrictEqual(params, []);
   });
@@ -165,17 +165,17 @@ describe("makeQueryTemplate", () => {
     const operations = {...baseOperations};
   
     operations.slice = {from: 10, to: 20};
-    let [parts, ...params] = makeQueryTemplate(source, operations);
+    let [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nLIMIT 10 OFFSET 10");
     assert.deepStrictEqual(params, []);
   
     operations.slice = {from: null, to: 20};
-    [parts, ...params] = makeQueryTemplate(source, operations);
+    [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nLIMIT 20");
     assert.deepStrictEqual(params, []);
   
     operations.slice = {from: 10, to: null};
-    [parts, ...params] = makeQueryTemplate(source, operations);
+    [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(parts.join("?"), `SELECT t.col1,t.col2 FROM table1 t\nLIMIT ${1e9} OFFSET 10`);
     assert.deepStrictEqual(params, []);
   });
@@ -207,7 +207,7 @@ describe("makeQueryTemplate", () => {
       ]
     };
   
-    const [parts, ...params] = makeQueryTemplate(source, operations);
+    const [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2,t.col3 FROM table1 t\nWHERE t.col1 >= ?\nAND t.col2 = ?\nORDER BY t.col1 ASC\nLIMIT 90 OFFSET 10");
     assert.deepStrictEqual(params, ["val1", "val2"]);
   });

--- a/test/table-test.mjs
+++ b/test/table-test.mjs
@@ -245,7 +245,7 @@ describe("__table", () => {
     assert.throws(() => __table(source, operations), /unknown filter type: xyz/);
   });
 
-  it("__table filter", () => {
+  it("__table filter lt + gt", () => {
     const operationsEquals = {
       ...EMPTY_TABLE_DATA.operations,
       filter: [{type: "eq", operands: [{type: "column", value: "a"}, {type: "resolved", value: 1}]}]
@@ -259,6 +259,31 @@ describe("__table", () => {
       ]
     };
     assert.deepStrictEqual(__table(source, operationsComparison), [{a: 2, b: 4, c: 6}]);
+  });
+
+  it("__table filter lte + gte", () => {
+    const operationsEquals = {
+      ...EMPTY_TABLE_DATA.operations,
+      filter: [{type: "eq", operands: [{type: "column", value: "a"}, {type: "resolved", value: 1}]}]
+    };
+    assert.deepStrictEqual(__table(source, operationsEquals), [{a: 1, b: 2, c: 3}]);
+    const operationsComparison = {
+      ...EMPTY_TABLE_DATA.operations,
+      filter: [
+        {type: "lte", operands: [{type: "column", value: "a"}, {type: "resolved", value: 2.5}]},
+        {type: "gte", operands: [{type: "column", value: "b"}, {type: "resolved", value: 2.5}]}
+      ]
+    };
+    assert.deepStrictEqual(__table(source, operationsComparison), [{a: 2, b: 4, c: 6}]);
+  });
+
+  it("__table filter eq date", () => {
+    const operationsEquals = {
+      ...EMPTY_TABLE_DATA.operations,
+      filter: [{type: "eq", operands: [{type: "column", value: "a"}, {type: "resolved", value: new Date("2021-01-02")}]}]
+    };
+    const source = [{a: new Date("2021-01-01")}, {a: new Date("2021-01-02")}, {a: new Date("2021-01-03")}];
+    assert.deepStrictEqual(__table(source, operationsEquals), [{a: new Date("2021-01-02")}]);
   });
 
   it("__table sort", () => {

--- a/test/table-test.mjs
+++ b/test/table-test.mjs
@@ -1,4 +1,4 @@
-import {makeQueryTemplate} from "../src/table.mjs";
+import {makeQueryTemplate, __table} from "../src/table.mjs";
 import assert from "assert";
 
 export const EMPTY_TABLE_DATA = {
@@ -35,178 +35,261 @@ const baseOperations = {
   }
 };
 
-it("makeQueryTemplate null table", () => {
-  const source = {};
-  assert.strictEqual(makeQueryTemplate(EMPTY_TABLE_DATA.operations, source), undefined);
-});
-
-it("makeQueryTemplate no selected columns", () => {
-  const source = {name: "db", dialect: "postgres"};
-  const operationsColumnsNull = {...baseOperations, select: {columns: null}};
-  assert.strictEqual(makeQueryTemplate(operationsColumnsNull, source), undefined);
-  const operationsColumnsEmpty = {...baseOperations, select: {columns: []}};
-  assert.strictEqual(makeQueryTemplate(operationsColumnsEmpty, source), undefined);
-});
-
-it("makeQueryTemplate invalid filter operation", () => {
-  const source = {name: "db", dialect: "postgres"};
-  const invalidFilters = [
-    {
-      type: "n",
-      operands: [
-        {type: "column", value: "col1"},
-        {type: "primitive", value: "val1"}
-      ]
-    },
-    {
-      type: "eq",
-      operands: [{type: "column", value: "col1"}]
-    },
-    {
-      type: "lt",
-      operands: [
-        {type: "column", value: "col1"},
-        {type: "primitive", value: "val1"},
-        {type: "primitive", value: "val2"}
-      ]
-    }
-  ];
-
-  invalidFilters.map((filter) => {
-    const operations = {
-      ...baseOperations,
-      filter: [filter]
-    };
-    assert.throws(() => makeQueryTemplate(operations, source), /Invalid filter operation/);
+describe("makeQueryTemplate", () => {
+  it("makeQueryTemplate null table", () => {
+    const source = {};
+    assert.strictEqual(makeQueryTemplate(source, EMPTY_TABLE_DATA.operations), undefined);
   });
-});
-
-it("makeQueryTemplate filter", () => {
-  const source = {name: "db", dialect: "postgres"};
-  const operations = {
-    ...baseOperations,
-    filter: [
+  
+  it("makeQueryTemplate no selected columns", () => {
+    const source = {name: "db", dialect: "postgres"};
+    const operationsColumnsNull = {...baseOperations, select: {columns: null}};
+    assert.strictEqual(makeQueryTemplate(source, operationsColumnsNull), undefined);
+    const operationsColumnsEmpty = {...baseOperations, select: {columns: []}};
+    assert.strictEqual(makeQueryTemplate(source, operationsColumnsEmpty), undefined);
+  });
+  
+  it("makeQueryTemplate invalid filter operation", () => {
+    const source = {name: "db", dialect: "postgres"};
+    const invalidFilters = [
       {
-        type: "eq",
+        type: "n",
         operands: [
           {type: "column", value: "col1"},
           {type: "primitive", value: "val1"}
         ]
-      }
-    ]
-  };
-
-  const [parts, ...params] = makeQueryTemplate(operations, source);
-  assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nWHERE t.col1 = ?");
-  assert.deepStrictEqual(params, ["val1"]);
-});
-
-it("makeQueryTemplate filter list", () => {
-  const source = {name: "db", dialect: "postgres"};
-  const operations = {
-    ...baseOperations,
-    filter: [
+      },
       {
-        type: "in",
+        type: "eq",
+        operands: [{type: "column", value: "col1"}]
+      },
+      {
+        type: "lt",
         operands: [
           {type: "column", value: "col1"},
           {type: "primitive", value: "val1"},
-          {type: "primitive", value: "val2"},
-          {type: "primitive", value: "val3"}
-        ]
-      },
-      {
-        type: "nin",
-        operands: [
-          {type: "column", value: "col1"},
-          {type: "primitive", value: "val4"}
-        ]
-      }
-    ]
-  };
-
-  const [parts, ...params] = makeQueryTemplate(operations, source);
-  assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nWHERE t.col1 IN (?,?,?)\nAND t.col1 NOT IN (?)");
-  assert.deepStrictEqual(params, ["val1", "val2", "val3", "val4"]);
-});
-
-it("makeQueryTemplate select", () => {
-  const source = {name: "db", dialect: "mysql"};
-  const operations = {
-    ...baseOperations,
-    select: {
-      columns: ["col1", "col2", "col3"]
-    }
-  };
-
-  const [parts, ...params] = makeQueryTemplate(operations, source);
-  assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2,t.col3 FROM table1 t");
-  assert.deepStrictEqual(params, []);
-});
-
-it("makeQueryTemplate sort", () => {
-  const source = {name: "db", dialect: "mysql"};
-  const operations = {
-    ...baseOperations,
-    sort: [
-      {column: "col1", direction: "asc"},
-      {column: "col2", direction: "desc"}
-    ]
-  };
-
-  const [parts, ...params] = makeQueryTemplate(operations, source);
-  assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nORDER BY t.col1 ASC, t.col2 DESC");
-  assert.deepStrictEqual(params, []);
-});
-
-it("makeQueryTemplate slice", () => {
-  const source = {name: "db", dialect: "mysql"};
-  const operations = {...baseOperations};
-
-  operations.slice = {from: 10, to: 20};
-  let [parts, ...params] = makeQueryTemplate(operations, source);
-  assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nLIMIT 10 OFFSET 10");
-  assert.deepStrictEqual(params, []);
-
-  operations.slice = {from: null, to: 20};
-  [parts, ...params] = makeQueryTemplate(operations, source);
-  assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nLIMIT 20");
-  assert.deepStrictEqual(params, []);
-
-  operations.slice = {from: 10, to: null};
-  [parts, ...params] = makeQueryTemplate(operations, source);
-  assert.deepStrictEqual(parts.join("?"), `SELECT t.col1,t.col2 FROM table1 t\nLIMIT ${1e9} OFFSET 10`);
-  assert.deepStrictEqual(params, []);
-});
-
-it("makeQueryTemplate select, sort, slice, filter indexed", () => {
-  const source = {name: "db", dialect: "postgres"};
-  const operations = {
-    ...baseOperations,
-    select: {
-      columns: ["col1", "col2", "col3"]
-    },
-    sort: [{column: "col1", direction: "asc"}],
-    slice: {from: 10, to: 100},
-    filter: [
-      {
-        type: "gte",
-        operands: [
-          {type: "column", value: "col1"},
-          {type: "primitive", value: "val1"}
-        ]
-      },
-      {
-        type: "eq",
-        operands: [
-          {type: "column", value: "col2"},
           {type: "primitive", value: "val2"}
         ]
       }
-    ]
-  };
+    ];
+  
+    invalidFilters.map((filter) => {
+      const operations = {
+        ...baseOperations,
+        filter: [filter]
+      };
+      assert.throws(() => makeQueryTemplate(source, operations), /Invalid filter operation/);
+    });
+  });
+  
+  it("makeQueryTemplate filter", () => {
+    const source = {name: "db", dialect: "postgres"};
+    const operations = {
+      ...baseOperations,
+      filter: [
+        {
+          type: "eq",
+          operands: [
+            {type: "column", value: "col1"},
+            {type: "primitive", value: "val1"}
+          ]
+        }
+      ]
+    };
+  
+    const [parts, ...params] = makeQueryTemplate(source, operations);
+    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nWHERE t.col1 = ?");
+    assert.deepStrictEqual(params, ["val1"]);
+  });
+  
+  it("makeQueryTemplate filter list", () => {
+    const source = {name: "db", dialect: "postgres"};
+    const operations = {
+      ...baseOperations,
+      filter: [
+        {
+          type: "in",
+          operands: [
+            {type: "column", value: "col1"},
+            {type: "primitive", value: "val1"},
+            {type: "primitive", value: "val2"},
+            {type: "primitive", value: "val3"}
+          ]
+        },
+        {
+          type: "nin",
+          operands: [
+            {type: "column", value: "col1"},
+            {type: "primitive", value: "val4"}
+          ]
+        }
+      ]
+    };
+  
+    const [parts, ...params] = makeQueryTemplate(source, operations);
+    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nWHERE t.col1 IN (?,?,?)\nAND t.col1 NOT IN (?)");
+    assert.deepStrictEqual(params, ["val1", "val2", "val3", "val4"]);
+  });
+  
+  it("makeQueryTemplate select", () => {
+    const source = {name: "db", dialect: "mysql"};
+    const operations = {
+      ...baseOperations,
+      select: {
+        columns: ["col1", "col2", "col3"]
+      }
+    };
+  
+    const [parts, ...params] = makeQueryTemplate(source, operations);
+    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2,t.col3 FROM table1 t");
+    assert.deepStrictEqual(params, []);
+  });
+  
+  it("makeQueryTemplate sort", () => {
+    const source = {name: "db", dialect: "mysql"};
+    const operations = {
+      ...baseOperations,
+      sort: [
+        {column: "col1", direction: "asc"},
+        {column: "col2", direction: "desc"}
+      ]
+    };
+  
+    const [parts, ...params] = makeQueryTemplate(source, operations);
+    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nORDER BY t.col1 ASC, t.col2 DESC");
+    assert.deepStrictEqual(params, []);
+  });
+  
+  it("makeQueryTemplate slice", () => {
+    const source = {name: "db", dialect: "mysql"};
+    const operations = {...baseOperations};
+  
+    operations.slice = {from: 10, to: 20};
+    let [parts, ...params] = makeQueryTemplate(source, operations);
+    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nLIMIT 10 OFFSET 10");
+    assert.deepStrictEqual(params, []);
+  
+    operations.slice = {from: null, to: 20};
+    [parts, ...params] = makeQueryTemplate(source, operations);
+    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nLIMIT 20");
+    assert.deepStrictEqual(params, []);
+  
+    operations.slice = {from: 10, to: null};
+    [parts, ...params] = makeQueryTemplate(source, operations);
+    assert.deepStrictEqual(parts.join("?"), `SELECT t.col1,t.col2 FROM table1 t\nLIMIT ${1e9} OFFSET 10`);
+    assert.deepStrictEqual(params, []);
+  });
+  
+  it("makeQueryTemplate select, sort, slice, filter indexed", () => {
+    const source = {name: "db", dialect: "postgres"};
+    const operations = {
+      ...baseOperations,
+      select: {
+        columns: ["col1", "col2", "col3"]
+      },
+      sort: [{column: "col1", direction: "asc"}],
+      slice: {from: 10, to: 100},
+      filter: [
+        {
+          type: "gte",
+          operands: [
+            {type: "column", value: "col1"},
+            {type: "primitive", value: "val1"}
+          ]
+        },
+        {
+          type: "eq",
+          operands: [
+            {type: "column", value: "col2"},
+            {type: "primitive", value: "val2"}
+          ]
+        }
+      ]
+    };
+  
+    const [parts, ...params] = makeQueryTemplate(source, operations);
+    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2,t.col3 FROM table1 t\nWHERE t.col1 >= ?\nAND t.col2 = ?\nORDER BY t.col1 ASC\nLIMIT 90 OFFSET 10");
+    assert.deepStrictEqual(params, ["val1", "val2"]);
+  });
+});
 
-  const [parts, ...params] = makeQueryTemplate(operations, source);
-  assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2,t.col3 FROM table1 t\nWHERE t.col1 >= ?\nAND t.col2 = ?\nORDER BY t.col1 ASC\nLIMIT 90 OFFSET 10");
-  assert.deepStrictEqual(params, ["val1", "val2"]);
+describe("__table", () => {
+  let source;
+
+  beforeEach(() => {
+    source = [{a: 1, b: 2, c: 3}, {a: 2, b: 4, c: 6}, {a: 3, b: 6, c: 9}];
+  });
+
+  it("__table no operations", () => {
+    assert.deepStrictEqual(__table(source, EMPTY_TABLE_DATA.operations), source);
+  });
+
+  it("__table columns", () => {
+    const operationsNullColumns = {...EMPTY_TABLE_DATA.operations, select: {columns: null}};
+    assert.deepStrictEqual(__table(source, operationsNullColumns), source);
+    const operationsEmptyColumns = {...EMPTY_TABLE_DATA.operations, select: {columns: []}};
+    assert.deepStrictEqual(__table(source, operationsEmptyColumns), [{}, {}, {}]);
+    const operationsSelectedColumns = {...EMPTY_TABLE_DATA.operations, select: {columns: ["a"]}};
+    assert.deepStrictEqual(__table(source, operationsSelectedColumns), [{a: 1}, {a: 2}, {a: 3}]);
+  });
+
+  it("__table unknown filter", () => {
+    const operations = {
+      ...EMPTY_TABLE_DATA.operations,
+      filter: [{type: "xyz", operands: [{type: "column", value: "a"}]}]
+    };
+    assert.throws(() => __table(source, operations), /unknown filter type: xyz/);
+  });
+
+  it("__table filter", () => {
+    const operationsEquals = {
+      ...EMPTY_TABLE_DATA.operations,
+      filter: [{type: "eq", operands: [{type: "column", value: "a"}, {type: "resolved", value: 1}]}]
+    };
+    assert.deepStrictEqual(__table(source, operationsEquals), [{a: 1, b: 2, c: 3}]);
+    const operationsComparison = {
+      ...EMPTY_TABLE_DATA.operations,
+      filter: [
+        {type: "lt", operands: [{type: "column", value: "a"}, {type: "resolved", value: 3}]},
+        {type: "gt", operands: [{type: "column", value: "b"}, {type: "resolved", value: 2}]}
+      ]
+    };
+    assert.deepStrictEqual(__table(source, operationsComparison), [{a: 2, b: 4, c: 6}]);
+  });
+
+  it("__table sort", () => {
+    const operations1 = {...EMPTY_TABLE_DATA.operations, sort: [{column: "a", direction: "desc"}]};
+    assert.deepStrictEqual(
+      __table(source, operations1),
+      [{a: 3, b: 6, c: 9}, {a: 2, b: 4, c: 6}, {a: 1, b: 2, c: 3}]
+    );
+    const sourceExtended = [...source, {a: 1, b: 3, c: 3}, {a: 1, b: 5, c: 3}];
+    const operations2 = {
+      ...EMPTY_TABLE_DATA.operations,
+      sort: [{column: "a", direction: "desc"}, {column: "b", direction: "desc"}]
+    };
+    assert.deepStrictEqual(
+      __table(sourceExtended, operations2),
+      [{a: 3, b: 6, c: 9}, {a: 2, b: 4, c: 6}, {a: 1, b: 5, c: 3}, {a: 1, b: 3, c: 3}, {a: 1, b: 2, c: 3}]
+    );
+  });
+
+  it("__table slice", () => {
+    const operationsToNull = {...EMPTY_TABLE_DATA.operations, slice: {from: 1, to: null}};
+    assert.deepStrictEqual(__table(source, operationsToNull), [{a: 2, b: 4, c: 6}, {a: 3, b: 6, c: 9}]);
+    const operationsFromNull = {...EMPTY_TABLE_DATA.operations, slice: {from: null, to: 1}};
+    assert.deepStrictEqual(__table(source, operationsFromNull), [{a: 1, b: 2, c: 3}]);
+    const operations = {...EMPTY_TABLE_DATA.operations, slice: {from: 1, to: 2}};
+    assert.deepStrictEqual(__table(source, operations), [{a: 2, b: 4, c: 6}]);
+  });
+
+  it("__table retains schema and columns info", () => {
+    source.columns = ["a", "b", "c"];
+    assert.deepStrictEqual(__table(source, EMPTY_TABLE_DATA.operations).columns, ["a", "b", "c"]);
+    source.schema = [{name: "a", type: "number"}, {name: "b", type: "number"}, {name: "c", type: "number"}];
+    assert.deepStrictEqual(
+      __table(source, EMPTY_TABLE_DATA.operations).schema,
+      [{name: "a", type: "number"}, {name: "b", type: "number"}, {name: "c", type: "number"}]
+    );
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,6 +487,13 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+d3-array@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-3.2.0.tgz#15bf96cd9b7333e02eb8de8053d78962eafcff14"
+  integrity sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==
+  dependencies:
+    internmap "1 - 2"
+
 d3-dsv@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-2.0.0.tgz#b37b194b6df42da513a120d913ad1be22b5fe7c5"
@@ -915,6 +922,11 @@ inherits@2, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+"internmap@1 - 2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/internmap/-/internmap-2.0.3.tgz#6685f23755e43c524e251d29cbc97248e3061009"
+  integrity sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
 
 is-binary-path@~2.1.0:
   version "2.1.0"


### PR DESCRIPTION
This PR ports over @mbostock's `__table` function, as defined in https://github.com/observablehq/observablehq/pull/8300, and adds missing support for the `lt` and `gt` filter operations. Also adds unit tests.