### PR TITLE
use DuckDB for more data sources

### DIFF
--- a/src/arrow.js
+++ b/src/arrow.js
@@ -1,3 +1,6 @@
+import {arrow9 as arrow} from "./dependencies.js";
+import {cdn} from "./require.js";
+
 // Returns true if the vaue is an Apache Arrow table. This uses a “duck” test
 // (instead of strict instanceof) because we want it to work with a range of
 // Apache Arrow versions at least 7.0.0 or above.
@@ -55,4 +58,8 @@ function getArrowType(type) {
     default:
       return "other";
   }
+}
+
+export async function loadArrow() {
+  return await import(`${cdn}${arrow.resolve()}`);
 }

--- a/src/duckdb.js
+++ b/src/duckdb.js
@@ -111,7 +111,7 @@ export class DuckDBClient {
   }
 
   async describeColumns({table} = {}) {
-    const columns = await this.query(`DESCRIBE ${table}`);
+    const columns = await this.query(`DESCRIBE ${this.escape(table)}`);
     return columns.map(({column_name, column_type, null: nullable}) => ({
       name: column_name,
       type: getDuckDBType(column_type),

--- a/src/duckdb.js
+++ b/src/duckdb.js
@@ -1,5 +1,5 @@
-import {getArrowTableSchema, isArrowTable} from "./arrow.js";
-import {arrow9 as arrow, duckdb} from "./dependencies.js";
+import {getArrowTableSchema, isArrowTable, loadArrow} from "./arrow.js";
+import {duckdb} from "./dependencies.js";
 import {FileAttachment} from "./fileAttachment.js";
 import {cdn} from "./require.js";
 
@@ -202,11 +202,9 @@ async function insertFile(database, name, file, options) {
 }
 
 async function insertArrowTable(database, name, table, options) {
-  const arrow = await loadArrow();
-  const buffer = arrow.tableToIPC(table);
   const connection = await database.connect();
   try {
-    await connection.insertArrowFromIPCStream(buffer, {
+    await connection.insertArrowTable(table, {
       name,
       schema: "main",
       ...options
@@ -239,10 +237,6 @@ async function createDuckDB() {
   const db = new duck.AsyncDuckDB(logger, worker);
   await db.instantiate(bundle.mainModule);
   return db;
-}
-
-async function loadArrow() {
-  return await import(`${cdn}${arrow.resolve()}`);
 }
 
 // https://duckdb.org/docs/sql/data_types/overview

--- a/src/duckdb.js
+++ b/src/duckdb.js
@@ -169,9 +169,11 @@ async function insertFile(database, name, file, options) {
   try {
     switch (file.mimeType) {
       case "text/csv":
+      case "text/tab-separated-values":
         return await connection.insertCSVFromPath(file.name, {
           name,
           schema: "main",
+          delimiter: file.mimeType === "text/csv" ? "," : "\t",
           ...options
         });
       case "application/json":

--- a/src/duckdb.js
+++ b/src/duckdb.js
@@ -248,6 +248,7 @@ function getDuckDBType(type) {
       return "bigint";
     case "DOUBLE":
     case "REAL":
+    case "FLOAT":
       return "number";
     case "INTEGER":
     case "SMALLINT":

--- a/src/table.js
+++ b/src/table.js
@@ -278,9 +278,9 @@ export function makeQueryTemplate(operations, source) {
     throw new Error("missing from table");
   if (select.columns && select.columns.length === 0)
     throw new Error("at least one column must be selected");
-  const columns = select.columns ? select.columns.map((c) => `t.${escaper(c)}`) : "*";
+  const columns = select.columns ? select.columns.map(escaper).join(", ") : "*";
   const args = [
-    [`SELECT ${columns} FROM ${formatTable(from.table, escaper)} t`]
+    [`SELECT ${columns} FROM ${formatTable(from.table, escaper)}`]
   ];
   for (let i = 0; i < filter.length; ++i) {
     appendSql(i ? `\nAND ` : `\nWHERE `, args);
@@ -343,7 +343,7 @@ function appendSql(sql, args) {
 }
 
 function appendOrderBy({column, direction}, args, escaper) {
-  appendSql(`t.${escaper(column)} ${direction.toUpperCase()}`, args);
+  appendSql(`${escaper(column)} ${direction.toUpperCase()}`, args);
 }
 
 function appendWhereEntry({type, operands}, args, escaper) {
@@ -428,7 +428,7 @@ function appendWhereEntry({type, operands}, args, escaper) {
 
 function appendOperand(o, args, escaper) {
   if (o.type === "column") {
-    appendSql(`t.${escaper(o.value)}`, args);
+    appendSql(escaper(o.value), args);
   } else {
     args.push(o.value);
     args[0].push("");

--- a/src/table.js
+++ b/src/table.js
@@ -333,8 +333,9 @@ function formatTable(table, escaper) {
     if (table.schema != null) from += escaper(table.schema) + ".";
     from += escaper(table.table);
     return from;
+  } else {
+    return escaper(table);
   }
-  return table;
 }
 
 function appendSql(sql, args) {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -50,7 +50,7 @@ describe("makeQueryTemplate", () => {
   it("makeQueryTemplate select all", () => {
     const source = {name: "db", dialect: "postgres"};
     const operationsColumnsNull = {...baseOperations, select: {columns: null}};
-    assert.deepStrictEqual(makeQueryTemplate(operationsColumnsNull, source), [["SELECT * FROM table1 t"]]);
+    assert.deepStrictEqual(makeQueryTemplate(operationsColumnsNull, source), [["SELECT * FROM table1"]]);
   });
 
   it("makeQueryTemplate invalid filter operation", () => {
@@ -102,7 +102,7 @@ describe("makeQueryTemplate", () => {
     };
 
     const [parts, ...params] = makeQueryTemplate(operations, source);
-    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nWHERE t.col1 = ?");
+    assert.deepStrictEqual(parts.join("?"), "SELECT col1, col2 FROM table1\nWHERE col1 = ?");
     assert.deepStrictEqual(params, ["val1"]);
   });
 
@@ -124,7 +124,7 @@ describe("makeQueryTemplate", () => {
     const [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(
       parts.join("?"),
-      "SELECT t._col1_,t._col2_ FROM table1 t\nWHERE t._col2_ = ?"
+      "SELECT _col1_, _col2_ FROM table1\nWHERE _col2_ = ?"
     );
     assert.deepStrictEqual(params, ["val1"]);
   });
@@ -148,7 +148,7 @@ describe("makeQueryTemplate", () => {
     const [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(
         parts.join("?"),
-        "SELECT t._col1_,t._col2_ FROM table1 t\nWHERE t._col2_ = ?"
+        "SELECT _col1_, _col2_ FROM table1\nWHERE _col2_ = ?"
     );
     assert.deepStrictEqual(params, ["val1"]);
   });
@@ -178,7 +178,7 @@ describe("makeQueryTemplate", () => {
     };
 
     const [parts, ...params] = makeQueryTemplate(operations, source);
-    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nWHERE t.col1 IN (?,?,?)\nAND t.col1 NOT IN (?)");
+    assert.deepStrictEqual(parts.join("?"), "SELECT col1, col2 FROM table1\nWHERE col1 IN (?,?,?)\nAND col1 NOT IN (?)");
     assert.deepStrictEqual(params, ["val1", "val2", "val3", "val4"]);
   });
 
@@ -192,7 +192,7 @@ describe("makeQueryTemplate", () => {
     };
 
     const [parts, ...params] = makeQueryTemplate(operations, source);
-    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2,t.col3 FROM table1 t");
+    assert.deepStrictEqual(parts.join("?"), "SELECT col1, col2, col3 FROM table1");
     assert.deepStrictEqual(params, []);
   });
 
@@ -207,7 +207,7 @@ describe("makeQueryTemplate", () => {
     };
 
     const [parts, ...params] = makeQueryTemplate(operations, source);
-    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nORDER BY t.col1 ASC, t.col2 DESC");
+    assert.deepStrictEqual(parts.join("?"), "SELECT col1, col2 FROM table1\nORDER BY col1 ASC, col2 DESC");
     assert.deepStrictEqual(params, []);
   });
 
@@ -224,7 +224,7 @@ describe("makeQueryTemplate", () => {
     const [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(
       parts.join("?"),
-      "SELECT t._col1_,t._col2_ FROM table1 t\nORDER BY t._col1_ ASC, t._col2_ DESC"
+      "SELECT _col1_, _col2_ FROM table1\nORDER BY _col1_ ASC, _col2_ DESC"
     );
     assert.deepStrictEqual(params, []);
   });
@@ -235,17 +235,17 @@ describe("makeQueryTemplate", () => {
 
     operations.slice = {from: 10, to: 20};
     let [parts, ...params] = makeQueryTemplate(operations, source);
-    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nLIMIT 10 OFFSET 10");
+    assert.deepStrictEqual(parts.join("?"), "SELECT col1, col2 FROM table1\nLIMIT 10 OFFSET 10");
     assert.deepStrictEqual(params, []);
 
     operations.slice = {from: null, to: 20};
     [parts, ...params] = makeQueryTemplate(operations, source);
-    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2 FROM table1 t\nLIMIT 20");
+    assert.deepStrictEqual(parts.join("?"), "SELECT col1, col2 FROM table1\nLIMIT 20");
     assert.deepStrictEqual(params, []);
 
     operations.slice = {from: 10, to: null};
     [parts, ...params] = makeQueryTemplate(operations, source);
-    assert.deepStrictEqual(parts.join("?"), `SELECT t.col1,t.col2 FROM table1 t\nLIMIT ${1e9} OFFSET 10`);
+    assert.deepStrictEqual(parts.join("?"), `SELECT col1, col2 FROM table1\nLIMIT ${1e9} OFFSET 10`);
     assert.deepStrictEqual(params, []);
   });
 
@@ -277,7 +277,7 @@ describe("makeQueryTemplate", () => {
     };
 
     const [parts, ...params] = makeQueryTemplate(operations, source);
-    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2,t.col3 FROM table1 t\nWHERE t.col1 >= ?\nAND t.col2 = ?\nORDER BY t.col1 ASC\nLIMIT 90 OFFSET 10");
+    assert.deepStrictEqual(parts.join("?"), "SELECT col1, col2, col3 FROM table1\nWHERE col1 >= ?\nAND col2 = ?\nORDER BY col1 ASC\nLIMIT 90 OFFSET 10");
     assert.deepStrictEqual(params, ["val1", "val2"]);
   });
 
@@ -294,7 +294,7 @@ describe("makeQueryTemplate", () => {
     const [parts] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(
       parts.join("?"),
-      "SELECT t._col1_,t._col2_,t._col3_ FROM table1 t\nORDER BY t._col1_ ASC\nOFFSET 0 ROWS\nFETCH NEXT 100 ROWS ONLY"
+      "SELECT _col1_, _col2_, _col3_ FROM table1\nORDER BY _col1_ ASC\nOFFSET 0 ROWS\nFETCH NEXT 100 ROWS ONLY"
     );
   });
 
@@ -326,7 +326,7 @@ describe("makeQueryTemplate", () => {
     };
 
     const [parts, ...params] = makeQueryTemplate(operations, source);
-    assert.deepStrictEqual(parts.join("?"), "SELECT t.col1,t.col2,t.col3 FROM table1 t\nWHERE t.col1 >= ?\nAND t.col2 = ?\nORDER BY t.col2 DESC\nOFFSET 10 ROWS\nFETCH NEXT 90 ROWS ONLY");
+    assert.deepStrictEqual(parts.join("?"), "SELECT col1, col2, col3 FROM table1\nWHERE col1 >= ?\nAND col2 = ?\nORDER BY col2 DESC\nOFFSET 10 ROWS\nFETCH NEXT 90 ROWS ONLY");
     assert.deepStrictEqual(params, ["val1", "val2"]);
   });
 
@@ -358,7 +358,7 @@ describe("makeQueryTemplate", () => {
     };
 
     const [parts, ...params] = makeQueryTemplate(operations, source);
-    assert.deepStrictEqual(parts.join("?"), "SELECT * FROM table1 t\nORDER BY t.col2 DESC\nOFFSET 10 ROWS\nFETCH NEXT 90 ROWS ONLY");
+    assert.deepStrictEqual(parts.join("?"), "SELECT * FROM table1\nORDER BY col2 DESC\nOFFSET 10 ROWS\nFETCH NEXT 90 ROWS ONLY");
     assert.deepStrictEqual(params, []);
   });
 });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -124,7 +124,7 @@ describe("makeQueryTemplate", () => {
     const [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(
       parts.join("?"),
-      "SELECT _col1_, _col2_ FROM table1\nWHERE _col2_ = ?"
+      "SELECT _col1_, _col2_ FROM _table1_\nWHERE _col2_ = ?"
     );
     assert.deepStrictEqual(params, ["val1"]);
   });
@@ -148,7 +148,7 @@ describe("makeQueryTemplate", () => {
     const [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(
         parts.join("?"),
-        "SELECT _col1_, _col2_ FROM table1\nWHERE _col2_ = ?"
+        "SELECT _col1_, _col2_ FROM _table1_\nWHERE _col2_ = ?"
     );
     assert.deepStrictEqual(params, ["val1"]);
   });
@@ -224,7 +224,7 @@ describe("makeQueryTemplate", () => {
     const [parts, ...params] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(
       parts.join("?"),
-      "SELECT _col1_, _col2_ FROM table1\nORDER BY _col1_ ASC, _col2_ DESC"
+      "SELECT _col1_, _col2_ FROM _table1_\nORDER BY _col1_ ASC, _col2_ DESC"
     );
     assert.deepStrictEqual(params, []);
   });
@@ -294,7 +294,7 @@ describe("makeQueryTemplate", () => {
     const [parts] = makeQueryTemplate(operations, source);
     assert.deepStrictEqual(
       parts.join("?"),
-      "SELECT _col1_, _col2_, _col3_ FROM table1\nORDER BY _col1_ ASC\nOFFSET 0 ROWS\nFETCH NEXT 100 ROWS ONLY"
+      "SELECT _col1_, _col2_, _col3_ FROM _table1_\nORDER BY _col1_ ASC\nOFFSET 0 ROWS\nFETCH NEXT 100 ROWS ONLY"
     );
   });
 


### PR DESCRIPTION
This…

* Adopts DuckDB for CSV, TSV, JSON, Arrow and Parquet file sources for SQL cells
* Adopts DuckDB for Arrow and Parquet file sources for data table cells
* Adopts DuckDB for Arrow table sources for data table cells
* Fixes a bug with DuckDBClient.describeColumns when the table name needs escaping

🦆🦆🦆