### PR TITLE
use DuckDB’s auto delimiter by default

### DIFF
--- a/src/duckdb.js
+++ b/src/duckdb.js
@@ -173,7 +173,6 @@ async function insertFile(database, name, file, options) {
         return await connection.insertCSVFromPath(file.name, {
           name,
           schema: "main",
-          delimiter: file.mimeType === "text/csv" ? "," : "\t",
           ...options
         });
       case "application/json":


### PR DESCRIPTION
Rather than hard-coding CSV = comma and TSV = tab (despite the name), use DuckDB’s magical automatic delimiter inference by default. You can still specify a delimiter explicitly if you use the _delimiter_ option.

Ref. https://observablehq.com/d/f11bdd2a9af411c5