### PR TITLE
Fix sql table only processes first yield

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -178,13 +178,19 @@ function sourceCache(loadSource) {
     if (!source) throw new Error("data source not found");
     let promise = cache.get(source);
     if (!promise) {
+      let resolve;
       // Warning: do not await here! We need to populate the cache synchronously.
-      promise = loadSource(source, name);
+      promise = (new Promise(_resolve => {
+        resolve = _resolve;
+      })).then(source => loadSource(source, name));
+      cache.set(promise, resolve);
       cache.set(source, promise);
     }
+    if (source.done !== false) cache.get(promise)(source);
     return promise;
   };
 }
+
 
 const loadTableDataSource = sourceCache(async (source, name) => {
   if (source instanceof FileAttachment) {


### PR DESCRIPTION
When loadSource instantiates a DuckDB instance from an array data source, it caches the corresponding DuckDBClient instance using the array instance as key. When the data source yields subsequent updates, these are no longer processed, breaking the data flow between the data source and SQL cell.

This PR implements a stop-gap solution based on a suggestion by @Fil:
- we check for a .done property on the array (which we have on e.g. DuckDB data sources)
- it resolves to instantiate the client only when `.done !== false`

**Note that this does not solve the following case.** Given the data source
```js
data = {
  const result = [];
  yield (result.push({v: 1}), result);
  yield (result.push({v: 2}), result);
}
```
the following SQL cell will only list the first row:
```sql
select * from data
```