### PR TITLE
Update caching logic for tables

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -177,9 +177,10 @@ function sourceCache(loadSource) {
   return (source, name) => {
     if (!source) throw new Error("data source not found");
     let promise = cache.get(source);
-    if (!promise) {
+    if (!promise || (isDataArray(source) && source.length !== promise._numRows)) {
       // Warning: do not await here! We need to populate the cache synchronously.
       promise = loadSource(source, name);
+      promise._numRows = source.length; // This will be undefined for DatabaseClients
       cache.set(source, promise);
     }
     return promise;


### PR DESCRIPTION
Resolves https://github.com/observablehq/observablehq/issues/9381

I did see the other possible solution suggestion, to bypass the cache entirely for array sources that are not done. If that seems like a better solution, happy to revise. 