### PR TITLE
Support Arquero tables

### DIFF
--- a/src/duckdb.js
+++ b/src/duckdb.js
@@ -219,6 +219,8 @@ async function insertArrowTable(database, name, table, options) {
 }
 
 async function insertArqueroTable(database, name, source) {
+  // TODO When we have stdlib versioning and can upgrade Arquero to version 5,
+  // we can then call source.toArrow() directly, with insertArrowTable()
   const arrow = await loadArrow();
   const table = arrow.tableFromIPC(source.toArrowBuffer());
   return await insertArrowTable(database, name, table);

--- a/src/duckdb.js
+++ b/src/duckdb.js
@@ -135,9 +135,9 @@ export class DuckDBClient {
           await insertArrowTable(db, name, source);
         } else if (Array.isArray(source)) { // bare array of objects
           await insertArray(db, name, source);
-        } else if(isArqueroTable(source)) {
+        } else if (isArqueroTable(source)) {
           await insertArqueroTable(db, name, source);
-        }  else if ("data" in source) { // data + options
+        } else if ("data" in source) { // data + options
           const {data, ...options} = source;
           if (isArrowTable(data)) {
             await insertArrowTable(db, name, data, options);

--- a/src/index.js
+++ b/src/index.js
@@ -7,5 +7,6 @@ export {
   arrayIsPrimitive,
   isDataArray,
   isDatabaseClient,
+  isArqueroTable,
   __table as applyDataTableOperations
 } from "./table.js";

--- a/src/table.js
+++ b/src/table.js
@@ -202,8 +202,8 @@ const loadTableDataSource = sourceCache(async (source, name) => {
   // Arquero tables have a `toArrow` function
   if (typeof source.toArrow === "function") {
     const arrow = await loadArrow();
-    const arrowBuffer = arrow.tableFromIPC(source.toArrowBuffer());
-    return loadDuckDBClient(arrowBuffer, name);
+    const arrowTable = arrow.tableFromIPC(source.toArrowBuffer());
+    return loadDuckDBClient(arrowTable, name);
   }
   return source;
 });
@@ -224,8 +224,8 @@ const loadSqlDataSource = sourceCache(async (source, name) => {
   // Arquero tables have a `toArrow` function
   if (typeof source.toArrow === "function") {
     const arrow = await loadArrow();
-    const arrowBuffer = arrow.tableFromIPC(source.toArrowBuffer());
-    return loadDuckDBClient(arrowBuffer, name);
+    const arrowTable = arrow.tableFromIPC(source.toArrowBuffer());
+    return loadDuckDBClient(arrowTable, name);
   }
   return source;
 });

--- a/src/table.js
+++ b/src/table.js
@@ -142,8 +142,8 @@ function isTypedArray(value) {
 }
 
 export function isArqueroTable(value) {
-  // Arquero tables have a `toArrow` function
-  return typeof value.toArrow === "function";
+  // Arquero tables have a `toArrowBuffer` function
+  return value && typeof value.toArrowBuffer === "function";
 }
 
 // __query is used by table cells; __query.sql is used by SQL cells.

--- a/src/table.js
+++ b/src/table.js
@@ -199,6 +199,12 @@ const loadTableDataSource = sourceCache(async (source, name) => {
     throw new Error(`unsupported file type: ${source.mimeType}`);
   }
   if (isArrowTable(source)) return loadDuckDBClient(source, name);
+  // Arquero tables have a `toArrow` function
+  if (typeof source.toArrow === "function") {
+    const arrow = await loadArrow();
+    const arrowBuffer = arrow.tableFromIPC(source.toArrowBuffer());
+    return loadDuckDBClient(arrowBuffer, name);
+  }
   return source;
 });
 
@@ -215,6 +221,12 @@ const loadSqlDataSource = sourceCache(async (source, name) => {
   }
   if (isDataArray(source)) return loadDuckDBClient(await asArrowTable(source, name), name);
   if (isArrowTable(source)) return loadDuckDBClient(source, name);
+  // Arquero tables have a `toArrow` function
+  if (typeof source.toArrow === "function") {
+    const arrow = await loadArrow();
+    const arrowBuffer = arrow.tableFromIPC(source.toArrowBuffer());
+    return loadDuckDBClient(arrowBuffer, name);
+  }
   return source;
 });
 

--- a/src/table.js
+++ b/src/table.js
@@ -141,6 +141,11 @@ function isTypedArray(value) {
   );
 }
 
+export function isArqueroTable(value) {
+  // Arquero tables have a `toArrow` function
+  return typeof value.toArrow === "function";
+}
+
 // __query is used by table cells; __query.sql is used by SQL cells.
 export const __query = Object.assign(
   async (source, operations, invalidation, name) => {
@@ -198,13 +203,7 @@ const loadTableDataSource = sourceCache(async (source, name) => {
     if (/\.(arrow|parquet)$/i.test(source.name)) return loadDuckDBClient(source, name);
     throw new Error(`unsupported file type: ${source.mimeType}`);
   }
-  if (isArrowTable(source)) return loadDuckDBClient(source, name);
-  // Arquero tables have a `toArrow` function
-  if (typeof source.toArrow === "function") {
-    const arrow = await loadArrow();
-    const arrowTable = arrow.tableFromIPC(source.toArrowBuffer());
-    return loadDuckDBClient(arrowTable, name);
-  }
+  if (isArrowTable(source) || isArqueroTable(source)) return loadDuckDBClient(source, name);
   return source;
 });
 
@@ -220,13 +219,7 @@ const loadSqlDataSource = sourceCache(async (source, name) => {
     throw new Error(`unsupported file type: ${source.mimeType}`);
   }
   if (isDataArray(source)) return loadDuckDBClient(await asArrowTable(source, name), name);
-  if (isArrowTable(source)) return loadDuckDBClient(source, name);
-  // Arquero tables have a `toArrow` function
-  if (typeof source.toArrow === "function") {
-    const arrow = await loadArrow();
-    const arrowTable = arrow.tableFromIPC(source.toArrowBuffer());
-    return loadDuckDBClient(arrowTable, name);
-  }
+  if (isArrowTable(source) || isArqueroTable(source)) return loadDuckDBClient(source, name);
   return source;
 });
 


### PR DESCRIPTION
Resolves #330 

- Identifies Arquero tables by presence of a `toArrow` function
- Uses Arrow's `.tableFromIPC()` with Arquero's `.toArrowBuffer()` as source for a new DuckDBClient
