### PR TITLE
Fix sort order for SQLite tables

### DIFF
--- a/src/sqlite.js
+++ b/src/sqlite.js
@@ -29,7 +29,7 @@ export class SQLiteDatabaseClient {
     ]);
   }
   async describeTables({schema} = {}) {
-    return this.query(`SELECT NULLIF(schema, 'main') AS schema, name FROM pragma_table_list() WHERE type = 'table'${schema == null ? "" : ` AND schema = ?`} AND name NOT LIKE 'sqlite_%' ORDER BY name`, schema == null ? [] : [schema]);
+    return this.query(`SELECT NULLIF(schema, 'main') AS schema, name FROM pragma_table_list() WHERE type = 'table'${schema == null ? "" : ` AND schema = ?`} AND name NOT LIKE 'sqlite_%' ORDER BY schema, name`, schema == null ? [] : [schema]);
   }
   async describeColumns({schema, table} = {}) {
     if (table == null) throw new Error(`missing table`);

--- a/src/sqlite.js
+++ b/src/sqlite.js
@@ -29,7 +29,7 @@ export class SQLiteDatabaseClient {
     ]);
   }
   async describeTables({schema} = {}) {
-    return this.query(`SELECT NULLIF(schema, 'main') AS schema, name FROM pragma_table_list() WHERE type = 'table'${schema == null ? "" : ` AND schema = ?`} AND name NOT LIKE 'sqlite_%'`, schema == null ? [] : [schema]);
+    return this.query(`SELECT NULLIF(schema, 'main') AS schema, name FROM pragma_table_list() WHERE type = 'table'${schema == null ? "" : ` AND schema = ?`} AND name NOT LIKE 'sqlite_%' ORDER BY name`, schema == null ? [] : [schema]);
   }
   async describeColumns({schema, table} = {}) {
     if (table == null) throw new Error(`missing table`);


### PR DESCRIPTION
Resolves #333

- Adds `ORDER BY schema, name` to `describeTables`

Before|After
-|-
![Screen Shot 2022-11-30 at 12 56 34 PM](https://user-images.githubusercontent.com/111310561/204906984-58ca4885-03a7-4b8e-91fc-f952ea4d8487.png)|![Screen Shot 2022-11-30 at 12 56 56 PM](https://user-images.githubusercontent.com/111310561/204907017-ae1143af-4d06-47ca-b7a4-e97ba70d41d3.png)
