### PR TITLE
Fix v and nv filters in SQL

### DIFF
--- a/test/table-test.js
+++ b/test/table-test.js
@@ -182,6 +182,31 @@ describe("makeQueryTemplate", () => {
     assert.deepStrictEqual(params, ["val1", "val2", "val3", "val4"]);
   });
 
+  it("makeQueryTemplate filter valid and not valid", () => {
+    const source = {name: "db", dialect: "postgres"};
+    const operations = {
+      ...baseOperations,
+      filter: [
+        {
+          type: "v",
+          operands: [
+            {type: "column", value: "col1"},
+            {type: "primitive", value: "string"}
+          ]
+        },
+        {
+          type: "nv",
+          operands: [
+            {type: "column", value: "col2"},
+            {type: "primitive", value: "number"}
+          ]
+        }
+      ]
+    };
+    const [parts] = makeQueryTemplate(operations, source);
+    assert.deepStrictEqual(parts.join("?"), "SELECT col1, col2 FROM table1\nWHERE col1 IS NOT NULL\nAND col2 IS NULL");
+  });
+
   it("makeQueryTemplate select", () => {
     const source = {name: "db", dialect: "mysql"};
     const operations = {


### PR DESCRIPTION
This fixes a bug where `v` and `nv` filters don't work for SQL data sources 😬 The issue is that, because we handle those filters in the binary operation conditional block, we append the primitive value (which contains the expected type) to the SQL query https://github.com/observablehq/stdlib/blob/main/src/table.js#L420. You end up with a query with broken syntax in the `WHERE` clause:

<img width="1217" alt="Screen Shot 2022-12-16 at 13 06 59" src="https://user-images.githubusercontent.com/6464196/208162023-75f62f34-946d-4279-a5ac-54e7ea2d4158.png">

We should just consider `v` and `nv` to be unary operations (I think it was originally my suggestion to handle them in the binary op block so that's my bad!!). I also added a unit test for this case.
