### PR TITLE
DuckDB to import columns as strings as a fallback

### DIFF
--- a/src/duckdb.js
+++ b/src/duckdb.js
@@ -178,7 +178,7 @@ async function insertFile(database, name, file, options) {
           schema: "main",
           ...options
         }).catch(async (error) => {
-          // If initial attempt to create a DuckDB client resulted in a conversion
+          // If initial attempt to insert CSV resulted in a conversion
           // error, try again, this time treating all columns as strings. 
           if (error.toString().includes("Could not convert")) {
             return await insertUntypedCSV(connection, file, name);

--- a/src/duckdb.js
+++ b/src/duckdb.js
@@ -130,9 +130,7 @@ export class DuckDBClient {
     await Promise.all(
       Object.entries(sources).map(async ([name, source]) => {
         if (source instanceof FileAttachment) { // bare file
-          config.untyped
-          ? await insertFile(db, name, source, {}, config.untyped)
-          : await insertFile(db, name, source);
+          await insertFile(db, name, source, {}, config.untyped);
         } else if (isArrowTable(source)) { // bare arrow table
           await insertArrowTable(db, name, source);
         } else if (Array.isArray(source)) { // bare array of objects

--- a/src/duckdb.js
+++ b/src/duckdb.js
@@ -130,7 +130,9 @@ export class DuckDBClient {
     await Promise.all(
       Object.entries(sources).map(async ([name, source]) => {
         if (source instanceof FileAttachment) { // bare file
-          await insertFile(db, name, source);
+          config.untyped
+          ? await insertFile(db, name, source, {}, config.untyped)
+          : await insertFile(db, name, source);
         } else if (isArrowTable(source)) { // bare arrow table
           await insertArrowTable(db, name, source);
         } else if (Array.isArray(source)) { // bare array of objects
@@ -160,7 +162,7 @@ Object.defineProperty(DuckDBClient.prototype, "dialect", {
   value: "duckdb"
 });
 
-async function insertFile(database, name, file, options) {
+async function insertFile(database, name, file, options, untyped = false) {
   const url = await file.url();
   if (url.startsWith("blob:")) {
     const buffer = await file.arrayBuffer();
@@ -172,12 +174,17 @@ async function insertFile(database, name, file, options) {
   try {
     switch (file.mimeType) {
       case "text/csv":
-      case "text/tab-separated-values":
-        return await connection.insertCSVFromPath(file.name, {
-          name,
-          schema: "main",
-          ...options
-        });
+      case "text/tab-separated-values": {
+        if (untyped) {
+          return await insertUntypedCSV(connection, file, name);
+        } else {
+          return await connection.insertCSVFromPath(file.name, {
+            name,
+            schema: "main",
+            ...options
+          });
+        }
+      }
       case "application/json":
         return await connection.insertJSONFromPath(file.name, {
           name,
@@ -203,6 +210,13 @@ async function insertFile(database, name, file, options) {
   } finally {
     await connection.close();
   }
+}
+
+async function insertUntypedCSV(connection, file, name) {
+  const statement = await connection.prepare(
+    `CREATE TABLE '${name}' AS SELECT * FROM read_csv_auto(?, ALL_VARCHAR=TRUE)`
+  );
+  return await statement.send(file.name);
 }
 
 async function insertArrowTable(database, name, table, options) {

--- a/src/duckdb.js
+++ b/src/duckdb.js
@@ -173,7 +173,7 @@ async function insertFile(database, name, file, options) {
     switch (file.mimeType) {
       case "text/csv":
       case "text/tab-separated-values": {
-        const client = await connection.insertCSVFromPath(file.name, {
+        return await connection.insertCSVFromPath(file.name, {
           name,
           schema: "main",
           ...options
@@ -184,7 +184,6 @@ async function insertFile(database, name, file, options) {
             return await insertUntypedCSV(connection, file, name);
           }
         });
-        return client;
       }
       case "application/json":
         return await connection.insertJSONFromPath(file.name, {

--- a/src/table.js
+++ b/src/table.js
@@ -232,13 +232,16 @@ function loadDuckDBClient(
     ? getFileSourceName(source)
     : "__table"
 ) {
-  return DuckDBClient.of({[name]: source})
-    .catch(() => {
-      // If initial attempt to create a DuckDB client resulted in an error, try
-      // one more time, treating all columns as strings. 
-      // Could check error for a substring like "Could not convert", if this
-      // seems too costly for a catch-all error path.
-      return DuckDBClient.of({[name]: source}, {untyped: true});
+  const client = DuckDBClient.of({[name]: source});
+  return client
+    .catch((error) => {
+      // If initial attempt to create a DuckDB client resulted in a conversion
+      // error, try again, this time treating all columns as strings. 
+      if (error.toString().includes("Could not convert")) {
+        return DuckDBClient.of({[name]: source}, {untyped: true});
+      }
+      // If this is not a conversion error, return the original attempt.
+      return client;
     });
 }
 

--- a/src/table.js
+++ b/src/table.js
@@ -5,7 +5,6 @@ import {isArrowTable, loadArrow} from "./arrow.js";
 import {DuckDBClient} from "./duckdb.js";
 
 const nChecks = 20; // number of values to check in each array
-export const untyped = Symbol("untyped");
 
 // We support two levels of DatabaseClient. The simplest DatabaseClient
 // implements only the client.sql tagged template literal. More advanced
@@ -233,17 +232,7 @@ function loadDuckDBClient(
     ? getFileSourceName(source)
     : "__table"
 ) {
-  const client = DuckDBClient.of({[name]: source});
-  return client
-    .catch((error) => {
-      // If initial attempt to create a DuckDB client resulted in a conversion
-      // error, try again, this time treating all columns as strings. 
-      if (error.toString().includes("Could not convert")) {
-        return DuckDBClient.of({[name]: source}, {[untyped]: true});
-      }
-      // If this is not a conversion error, return the original attempt.
-      return client;
-    });
+  return DuckDBClient.of({[name]: source});
 }
 
 function getFileSourceName(file) {

--- a/src/table.js
+++ b/src/table.js
@@ -232,7 +232,14 @@ function loadDuckDBClient(
     ? getFileSourceName(source)
     : "__table"
 ) {
-  return DuckDBClient.of({[name]: source});
+  return DuckDBClient.of({[name]: source})
+    .catch(() => {
+      // If initial attempt to create a DuckDB client resulted in an error, try
+      // one more time, treating all columns as strings. 
+      // Could check error for a substring like "Could not convert", if this
+      // seems too costly for a catch-all error path.
+      return DuckDBClient.of({[name]: source}, {untyped: true});
+    });
 }
 
 function getFileSourceName(file) {

--- a/src/table.js
+++ b/src/table.js
@@ -5,6 +5,7 @@ import {isArrowTable, loadArrow} from "./arrow.js";
 import {DuckDBClient} from "./duckdb.js";
 
 const nChecks = 20; // number of values to check in each array
+export const untyped = Symbol("untyped");
 
 // We support two levels of DatabaseClient. The simplest DatabaseClient
 // implements only the client.sql tagged template literal. More advanced
@@ -238,7 +239,7 @@ function loadDuckDBClient(
       // If initial attempt to create a DuckDB client resulted in a conversion
       // error, try again, this time treating all columns as strings. 
       if (error.toString().includes("Could not convert")) {
-        return DuckDBClient.of({[name]: source}, {untyped: true});
+        return DuckDBClient.of({[name]: source}, {[untyped]: true});
       }
       // If this is not a conversion error, return the original attempt.
       return client;


### PR DESCRIPTION
Partially resolves https://github.com/observablehq/observablehq/issues/9857 

The two cases it resolves are:
1. @Fil's case with thousands of rows of "F", which DuckDB interpreted as boolean, then threw an error when it encountered an "M."  
2. Allison's case of ejecting to SQL and it silently failing due to a type mismatch.

Case 2 (and likely case 1) occurred when the mismatch was found in a row > 10240, as that's the (default?) sample size DuckDB checks when inferring types. 

Now, if `insertCSVFromPath` fails, we catch it, check whether it failed due to a conversion error, and if so, try again with all columns as strings. Only CSV and TSV files are affected by this change. 

The error for case 1 (before): 
![Screen Shot 2023-01-11 at 4 21 40 PM](https://user-images.githubusercontent.com/111310561/211949643-1e22a17f-2c9b-49fe-9d1f-96f8583c04cc.png)
Case 1 fixed (after):  
![Screen Shot 2023-01-11 at 4 21 55 PM](https://user-images.githubusercontent.com/111310561/211949698-01bad4bd-1780-453c-9597-4c3cf75d58b2.png)

Video showing before and after for case 2: 

https://user-images.githubusercontent.com/111310561/211949879-3281b4bf-047a-4866-a65c-358e1814eb44.mov

