### PR TITLE
Handle column renaming in makeQueryTemplate and __table

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -663,7 +663,7 @@ export function __table(source, operations) {
       Object.fromEntries(operations.select.columns.map((c) => [c, d[c]]))
     );
   }
-  if (operations.names) {
+  if (!primitive && operations.names) {
     const overridesByName = new Map(operations.names.map((n) => [n.column, n]));
     if (schema) {
       schema = schema.map((s) => {

--- a/src/table.js
+++ b/src/table.js
@@ -307,7 +307,11 @@ export function makeQueryTemplate(operations, source) {
     throw new Error("missing from table");
   if (select.columns && select.columns.length === 0)
     throw new Error("at least one column must be selected");
-  const columns = select.columns ? select.columns.map(escaper).join(", ") : "*";
+  const names = new Map(operations.names?.map(({column, name}) => [column, name]));
+  const columns = select.columns ? select.columns.map((column) =>  {
+    const override = names.get(column);
+    return override ? `${escaper(column)} AS ${escaper(override)}` : escaper(column);
+  }).join(", ") : "*";
   const args = [
     [`SELECT ${columns} FROM ${formatTable(from.table, escaper)}`]
   ];
@@ -657,6 +661,27 @@ export function __table(source, operations) {
     }
     source = source.map((d) =>
       Object.fromEntries(operations.select.columns.map((c) => [c, d[c]]))
+    );
+  }
+  if (operations.names) {
+    const overridesByName = new Map(operations.names.map((n) => [n.column, n]));
+    if (schema) {
+      schema = schema.map((s) => {
+        const override = overridesByName.get(s.name);
+        return ({...s, ...(override ? {name: override.name} : null)});
+      });
+    }
+    if (columns) {
+      columns = columns.map((c) => {
+        const override = overridesByName.get(c);
+        return override?.name ?? c;
+      });
+    }
+    source = source.map((d) =>
+      Object.fromEntries(Object.keys(d).map((k) => {
+        const override = overridesByName.get(k);
+        return [override?.name ?? k, d[k]];
+      }))
     );
   }
   if (primitive) source = source.map((d) => d.value);

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -36,7 +36,7 @@ const baseOperations = {
 };
 
 function escape(identifier) {
-  return `\`${identifier.replaceAll("`", "``")}\``;
+  return `\`${identifier.replace(/`/g, "``")}\``;
 }
 
 describe("makeQueryTemplate", () => {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -35,6 +35,10 @@ const baseOperations = {
   }
 };
 
+function escape(identifier) {
+  return `\`${identifier.replaceAll("`", "``")}\``;
+}
+
 describe("makeQueryTemplate", () => {
   it("makeQueryTemplate null table", () => {
     const source = {};
@@ -437,6 +441,25 @@ describe("makeQueryTemplate", () => {
     );
     assert.deepStrictEqual(params, ["val1", "val2"]);
   });
+
+  it("makeQueryTemplate names", () => {
+    const source = {name: "db", dialect: "mysql", escape};
+    let operations = {
+      ...baseOperations,
+      select: {
+        columns: ["col1", "col2", "col3"]
+      },
+      names: [
+        {column: "col1", name: "name1"},
+        {column: "col2", name: "name2"},
+        {column: "col3", name: "name3"}
+      ]
+    };
+
+    const [parts, ...params] = makeQueryTemplate(operations, source);
+    assert.deepStrictEqual(parts.join("?"), "SELECT `col1` AS `name1`, `col2` AS `name2`, `col3` AS `name3` FROM `table1`");
+    assert.deepStrictEqual(params, []);
+  });
 });
 
 describe("__table", () => {
@@ -583,6 +606,24 @@ describe("__table", () => {
     assert.deepStrictEqual(
       __table(source, EMPTY_TABLE_DATA.operations).schema,
       [{name: "a", type: "number"}, {name: "b", type: "number"}, {name: "c", type: "number"}]
+    );
+  });
+
+  it("__table names", () => {
+    const operations = {
+      ...EMPTY_TABLE_DATA.operations,
+      names: [{column: "a", name: "nameA"}]
+    };
+    assert.deepStrictEqual(__table(source, operations), [{nameA: 1, b: 2, c: 3}, {nameA: 2, b: 4, c: 6}, {nameA: 3, b: 6, c: 9}]);
+    source.columns = ["a", "b", "c"];
+    assert.deepStrictEqual(
+      __table(source, operations).columns,
+      ["nameA", "b", "c"]
+    );
+    source.schema = [{name: "a", type: "number"}, {name: "b", type: "number"}, {name: "c", type: "number"}];
+    assert.deepStrictEqual(
+      __table(source, operations).schema,
+      [{name: "nameA", type: "number"}, {name: "b", type: "number"}, {name: "c", type: "number"}]
     );
   });
 });


### PR DESCRIPTION
Implement column renaming in stdlib. Specifically, we now set column name overrides based on the `names` property in `node.data.operations`, which is added in [this PR](https://github.com/observablehq/observablehq/pull/10009).

For SQL data sources, we do this by modifying the `SELECT` clause. For in-memory data sources, we create a copy of the source data and modify it to use the new names.