### PR TITLE
Infer schemas and coerce data for table cells

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,5 @@ export {
   isDataArray,
   isDatabaseClient,
   __table as applyDataTableOperations,
-  getTypeValidator,
-  inferSchema
+  getTypeValidator
 } from "./table.js";

--- a/src/table.js
+++ b/src/table.js
@@ -607,11 +607,13 @@ export function coerceToType(value, type, options = {}) {
     }
     case "array":
       if (Array.isArray(value)) return value;
-      return value && Array.isArray(Array.from(value))
-        ? Array.from(value)
-        : defaultValue;
-    case "buffer":
+      return [value];
     case "object":
+      // this will return true for everything except null, undefined, strings,
+      // numbers, boolean, and symbols, so may yield unexpected results.
+      if (typeof value === "object") return value;
+      return {value: value};
+    case "buffer":
     case "other":
     default:
       return value || value === 0 ? value : defaultValue;

--- a/src/table.js
+++ b/src/table.js
@@ -798,7 +798,11 @@ export function inferSchema(source) {
         if (Array.isArray(value)) typeCounts[key].array++;
         else if (value instanceof Date) typeCounts[key].date++;
         else if (value instanceof ArrayBuffer) typeCounts[key].buffer++;
-        // number, bigint, boolean, or object
+        else if (type === "number") {
+          if (/^-?[0-9]+$/.test(value)) typeCounts[key].integer++;
+          else typeCounts[key].number++;
+        }
+        // bigint, boolean, or object
         else if (type in typeCounts[key]) typeCounts[key][type]++;
         else if (value !== null && value !== undefined) typeCounts[key].other++;
       } else {

--- a/src/table.js
+++ b/src/table.js
@@ -864,9 +864,6 @@ export function inferSchema(source, columns = getAllKeys(source)) {
         else if (DATE_TEST.test(value)) ++colCount.date;
       }
     }
-  }
-  for (const col in typeCounts) {
-    const colCount = typeCounts[col];
     // Chose the non-string, non-other type with the greatest count that is also
     // ≥90%; or if no such type meets that criterion, fallback to string if
     // ≥90%; and lastly fallback to other.

--- a/src/table.js
+++ b/src/table.js
@@ -620,7 +620,8 @@ export function __table(source, operations) {
   let {schema, columns} = source;
   let inferredSchema = false;
   if (!isQueryResultSetSchema(schema)) {
-    schema = inferSchema(source, columns);
+    if (arrayIsPrimitive(source)) schema = inferFromPrimitive(source, columns);
+    else schema = inferSchema(source, columns);
     inferredSchema = true;
   }
   let primitive = arrayIsPrimitive(source);
@@ -810,16 +811,18 @@ function getAllKeys(rows) {
   return Array.from(keys);
 }
 
+export function inferFromPrimitive(source) {
+  const primitiveSource = source.map((d) => {
+    return {value: d};
+  });
+ return inferSchema(primitiveSource, ["value"]);
+}
+
+
 export function inferSchema(source, columns = getAllKeys(source)) {
   const schema = [];
   const sampleSize = 100;
   let sample = source.slice(0, sampleSize);
-  if (arrayIsPrimitive(sample)) {
-    sample = sample.map((d) => {
-      return {value: d};
-    });
-    columns.push("value");
-  }
   const typeCounts = {};
   for (const d of sample) {
     for (const col of columns) {

--- a/src/table.js
+++ b/src/table.js
@@ -573,21 +573,21 @@ export function coerceToType(value, type) {
     case "bigint":
       return typeof value === "bigint" || value == null
         ? value
-        : Number.isInteger(typeof value === "string" && !value ? NaN : +value)
+        : Number.isInteger(typeof value === "string" && !value.trim() ? NaN : +value)
         ? BigInt(value) // eslint-disable-line no-undef
         : undefined;
     case "integer": // not a target type for coercion, but can be inferred
     case "number": {
       return typeof value === "number"
         ? value
-        : value == null || (typeof value === "string" && !value)
+        : value == null || (typeof value === "string" && !value.trim())
         ? NaN
         : Number(value);
     }
     case "date": {
       if (value instanceof Date || value == null) return value;
       if (typeof value === "number") return new Date(value);
-      if (typeof value === "string" && !value) return null;
+      if (typeof value === "string" && !value.trim()) return null;
       const trimValue = String(value).trim();
       return new Date(DATE_TEST.test(trimValue) ? trimValue : NaN);
     }
@@ -860,8 +860,7 @@ export function inferSchema(source, columns = getAllKeys(source)) {
         } else if (value && !isNaN(value)) {
           ++colCount.number;
           if (Number.isInteger(+value)) ++colCount.integer;
-        } else if (/^\d+n$/.test(value)) ++colCount.bigint;
-        else if (DATE_TEST.test(value)) ++colCount.date;
+        } else if (DATE_TEST.test(value)) ++colCount.date;
       }
     }
     // Chose the non-string, non-other type with the greatest count that is also

--- a/src/table.js
+++ b/src/table.js
@@ -582,7 +582,7 @@ export function coerceToType(value, type) {
     case "date": {
       if (value instanceof Date) return value;
       const trimValue = typeof value === "string" ? value.trim() : value;
-      return value && /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2}))|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))?([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/.test(trimValue)
+      return /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2}))|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/.test(trimValue)
         ? new Date(trimValue)
         : new Date("");
     }
@@ -857,8 +857,7 @@ function inferType(type, value) {
       else return "number";
     } else if (/^\d+n$/.test(value)) return "bigint";
     else if (
-      value &&
-      /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2}))|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))?([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/.test(value)
+      /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2}))|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/.test(value)
     )
       return "date";
     // the long regex accepts dates in the form of ISOString and

--- a/src/table.js
+++ b/src/table.js
@@ -819,9 +819,7 @@ export function inferSchema(source, columns = getAllKeys(source)) {
   for (const d of sample) {
     for (const col of columns) {
       if (!typeCounts[col]) typeCounts[col] = initKey();
-      const type = typeof d[col];
-      const value = type === "string" ? d[col].trim() : d[col];
-      typeCounts[col][inferType(type, value)]++;
+      typeCounts[col][inferType(d[col])]++;
     }
   }
   for (const col in typeCounts) {
@@ -839,7 +837,9 @@ export function inferSchema(source, columns = getAllKeys(source)) {
   return schema;
 }
 
-function inferType(type, value) {
+function inferType(colValue) {
+  const type = typeof colValue;
+  const value = type === "string" ? colValue.trim() : colValue;
   // for json and sqlite, we already have some types, but for csv and tsv, all
   // columns are strings here.
   const typedNonStrings = ["bigint", "boolean", "object"];

--- a/src/table.js
+++ b/src/table.js
@@ -564,7 +564,7 @@ export function coerceToType(value, type, options = {}) {
     case "bigint":
       return typeof value === "bigint"
         ? value
-        : !value || isNaN(value)
+        : !value || isNaN(value) || !Number.isInteger(+value)
         ? numberDefault
         // eslint-disable-next-line no-undef
         : BigInt(value);
@@ -808,7 +808,7 @@ export function inferSchema(source) {
         else if (value instanceof Date) typeCounts[key].date++;
         else if (value instanceof ArrayBuffer) typeCounts[key].buffer++;
         else if (type === "number") {
-          if (/^-?[0-9]+$/.test(value)) typeCounts[key].integer++;
+          if (Number.isInteger(+value)) typeCounts[key].integer++;
           else typeCounts[key].number++;
         }
         // bigint, boolean, or object
@@ -817,7 +817,7 @@ export function inferSchema(source) {
       } else {
         if (value === "true" || value === "false") typeCounts[key].boolean++;
         else if (value && !isNaN(value)) {
-          if (/^-?[0-9]+$/.test(value)) typeCounts[key].integer++;
+          if (Number.isInteger(+value)) typeCounts[key].integer++;
           else typeCounts[key].number++;
         } else if (
           value &&

--- a/src/table.js
+++ b/src/table.js
@@ -547,8 +547,8 @@ export function coerceToType(value, type, options = {}) {
   const defaultValue = options.soft ? value : null;
   const numberDefault = defaultValue === null ? NaN : defaultValue;
   switch (type) {
-    case "string":
-      return value === "string"
+    case "string": 
+      return typeof value === "string"
         ? value.trim()
         : value || value === 0
         ? value.toString()

--- a/src/table.js
+++ b/src/table.js
@@ -66,7 +66,12 @@ function objectHasEnumerableKeys(value) {
 }
 
 function isQueryResultSetSchema(schemas) {
-  return (Array.isArray(schemas) && schemas.every((s) => s && typeof s.name === "string" && typeof s.type === "string"));
+  return (
+    Array.isArray(schemas) &&
+    schemas.every(
+      (s) => s && typeof s.name === "string" && typeof s.type === "string"
+    )
+  );
 }
 
 function isQueryResultSetColumns(columns) {

--- a/src/table.js
+++ b/src/table.js
@@ -633,8 +633,9 @@ export function __table(source, operations) {
     for (const {name, type} of operations.type) {
       types.set(name, type);
       // update schema with user-selected type
+      if (schema === input.schema) schema = schema.slice(); // copy on write
       const colIndex = schema.findIndex((col) => col.name === name);
-      if (colIndex > -1) schema[colIndex] = {name, type};
+      if (colIndex > -1) schema[colIndex] = {...schema[colIndex], type};
     }
     source = source.map(d => coerceRow(d, types));
   }

--- a/src/table.js
+++ b/src/table.js
@@ -546,7 +546,6 @@ export function getTypeValidator(colType) {
 }
 
 export function coerceToType(value, type) {
-  const stringValue = typeof value === "string" ? value.trim() : value;
   switch (type) {
     case "string":
       return typeof value === "string" || value == null
@@ -586,14 +585,15 @@ export function coerceToType(value, type) {
     case "date": {
       if (value instanceof Date) return value;
       if (typeof value === "string") {
+        const trimValue = value.trim();
         let match;
         if (
-          (match = stringValue.match(
+          (match = trimValue.match(
             /^([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)?(T\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/
           ))
         ) {
           if (fixTz && !!match[4] && !match[7])
-            value = stringValue.replace(/-/g, "/").replace(/T/, " ");
+            value = trimValue.replace(/-/g, "/").replace(/T/, " ");
         }
       }
       return new Date(value);

--- a/src/table.js
+++ b/src/table.js
@@ -849,9 +849,16 @@ export function inferSchema(source) {
     }
   }
   for (const col in typeCounts) {
+    let type = greatest(Object.keys(typeCounts[col]), (d) => typeCounts[col][d]);
+    // If over 90% of the sampled data counted as this type, use it. Otherwise,
+    // use "other."
+    type =
+      typeCounts[col][type] / Math.min(source.length, sampleSize) >= 0.9
+        ? type
+        : "other";
     schema.push({
       name: col,
-      type: greatest(Object.keys(typeCounts[col]), (d) => typeCounts[col][d])
+      type: type
     });
   }
   return schema;

--- a/src/table.js
+++ b/src/table.js
@@ -850,7 +850,13 @@ export function inferSchema(source, columns = getAllKeys(source)) {
   }
   for (const col in typeCounts) {
     let type = greatest(Object.keys(typeCounts[col]), d => typeCounts[col][d]);
-    const numDefined = sample.filter(d => !(d[col] == null || d[col] === "")).length;
+    const numDefined = sample.filter(
+      (d) =>
+        !(
+          d[col] == null ||
+          (typeof d[col] === "string" && d[col].trim() === "")
+        )
+    ).length;
     // If over 90% of the sampled data counted as this type, use it. Otherwise,
     // use "other."
     type = typeCounts[col][type] / numDefined >= 0.9 ? type : "other";

--- a/src/table.js
+++ b/src/table.js
@@ -551,6 +551,9 @@ export function getTypeValidator(colType) {
   }
 }
 
+// Accepts dates in the form of ISOString and LocaleDateString, with or without time
+const DATE_TEST = /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2}))|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/;
+
 export function coerceToType(value, type) {
   switch (type) {
     case "string":
@@ -582,7 +585,7 @@ export function coerceToType(value, type) {
     case "date": {
       if (value instanceof Date) return value;
       const trimValue = typeof value === "string" ? value.trim() : value;
-      return /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2}))|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/.test(trimValue)
+      return DATE_TEST.test(trimValue)
         ? new Date(trimValue)
         : new Date("");
     }
@@ -856,12 +859,7 @@ function inferType(type, value) {
       if (Number.isInteger(+value)) return "integer";
       else return "number";
     } else if (/^\d+n$/.test(value)) return "bigint";
-    else if (
-      /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2}))|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/.test(value)
-    )
-      return "date";
-    // the long regex accepts dates in the form of ISOString and
-    // LocaleDateString, with or without times
+    else if (DATE_TEST.test(value)) return "date";
     else if (value) return "string";
     else return "other";
   }

--- a/src/table.js
+++ b/src/table.js
@@ -826,16 +826,11 @@ export function inferSchema(source, columns = getAllKeys(source)) {
     }
   }
   for (const col in typeCounts) {
-    let type = greatest(
-      Object.keys(typeCounts[col]),
-      (d) => typeCounts[col][d]
-    );
+    let type = greatest(Object.keys(typeCounts[col]), d => typeCounts[col][d]);
+    const numDefined = sample.filter(d => !(d[col] == null || d[col] === "")).length;
     // If over 90% of the sampled data counted as this type, use it. Otherwise,
     // use "other."
-    type =
-      typeCounts[col][type] / Math.min(source.length, sampleSize) >= 0.9
-        ? type
-        : "other";
+    type = typeCounts[col][type] / numDefined >= 0.9 ? type : "other";
     schema.push({
       name: col,
       type: type,

--- a/src/table.js
+++ b/src/table.js
@@ -853,7 +853,7 @@ function inferType(type, value) {
       else return "number";
     }
     else if (typedNonStrings.includes(type)) return type;
-    else if (value !== null && value !== undefined) return "other";
+    else return "other";
   } else {
     if (value === "true" || value === "false") return "boolean";
     else if (value && !isNaN(value)) {
@@ -867,5 +867,6 @@ function inferType(type, value) {
     // the long regex accepts dates in the form of ISOString and
     // LocaleDateString, with or without times
     else if (value) return "string";
+    else return "other";
   }
 }

--- a/src/table.js
+++ b/src/table.js
@@ -840,10 +840,7 @@ export function inferSchema(source, columns = getAllKeys(source)) {
           else typeCounts[col].number++;
         } else if (/^\d+n$/.test(value)) typeCounts[col].bigint++;
         else if (
-          value &&
-          value.match(
-            /^(([-+]\d{2})?\d{4}(-\d{1,2}(-\d{1,2})?)|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))?([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/
-          )
+          /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))?([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/.test(value)
         )
           typeCounts[col].date++;
         // the long regex accepts dates in the form of ISOString and

--- a/src/table.js
+++ b/src/table.js
@@ -591,7 +591,7 @@ export function coerceToType(value, type) {
     case "object":
     case "buffer":
     case "other":
-      return value || value === 0 ? value : null;
+      return value;
     default:
       throw new Error(`Unable to coerce to type: ${type}`);
   }

--- a/src/table.js
+++ b/src/table.js
@@ -829,7 +829,7 @@ export function inferSchema(source, columns = getAllKeys(source)) {
         else if (value instanceof ArrayBuffer) ++typeCounts[col].buffer;
         else if (type === "number") {
           ++typeCounts[col].number;
-          if (Number.isInteger(+value)) ++typeCounts[col].integer;
+          if (Number.isInteger(value)) ++typeCounts[col].integer;
         }
         // bigint, boolean, or object
         else if (type in typeCounts[col]) ++typeCounts[col][type];

--- a/src/table.js
+++ b/src/table.js
@@ -576,27 +576,16 @@ export function coerceToType(value, type) {
           BigInt(value);
     case "integer": // not a target type for coercion, but can be inferred
     case "number": {
-      return value === 0
+      return typeof value === "number"
         ? value
-        : !value || isNaN(value)
+        : value == null || value === ""
         ? NaN
         : Number(value);
     }
     case "date": {
       if (value instanceof Date) return value;
-      if (typeof value === "string") {
-        const trimValue = value.trim();
-        let match;
-        if (
-          (match = trimValue.match(
-            /^([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)?(T\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/
-          ))
-        ) {
-          if (fixTz && !!match[4] && !match[7])
-            value = trimValue.replace(/-/g, "/").replace(/T/, " ");
-        }
-      }
-      return new Date(value);
+      const trimValue = typeof value === "string" ? value.trim() : value;
+      return new Date(trimValue);
     }
     case "array":
     case "object":
@@ -785,11 +774,6 @@ function coerceRow(object, types, schema) {
   }
   return coerced;
 }
-
-// https://github.com/d3/d3-dsv/issues/45
-const fixTz =
-  new Date("2019-01-01T00:00").getHours() ||
-  new Date("2019-07-01T00:00").getHours();
 
 function initKey() {
   return {

--- a/src/table.js
+++ b/src/table.js
@@ -861,7 +861,8 @@ function inferType(type, value) {
       else return "number";
     } else if (/^\d+n$/.test(value)) return "bigint";
     else if (
-      /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))?([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/.test(value)
+      value &&
+      /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2}))|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))?([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/.test(value)
     )
       return "date";
     // the long regex accepts dates in the form of ISOString and

--- a/src/table.js
+++ b/src/table.js
@@ -621,7 +621,7 @@ export function __table(source, operations) {
   const input = source;
   let {schema, columns} = source;
   let inferredSchema = false;
-  if (!schema || !isQueryResultSetSchema(schema)) {
+  if (!isQueryResultSetSchema(schema)) {
     schema = inferSchema(source);
     inferredSchema = true;
   }

--- a/src/table.js
+++ b/src/table.js
@@ -560,10 +560,10 @@ export function coerceToType(value, type) {
       return typeof value === "string" || value == null ? value : String(value);
     case "boolean":
       if (typeof value === "string") {
-        const trimValue = value.trim();
-        return trimValue.toLowerCase() === "true"
+        const trimValue = value.trim().toLowerCase();
+        return trimValue === "true"
           ? true
-          : trimValue.toLowerCase() === "false"
+          : trimValue === "false"
           ? false
           : null;
       }

--- a/src/table.js
+++ b/src/table.js
@@ -559,12 +559,6 @@ export function coerceToType(value, type) {
       return typeof value === "boolean" || value == null
         ? value
         : Boolean(value);
-    case "integer":
-      return value === 0
-        ? value
-        : !value || isNaN(parseInt(value))
-        ? NaN
-        : parseInt(value);
     case "bigint":
       return typeof value === "bigint"
         ? value
@@ -575,6 +569,7 @@ export function coerceToType(value, type) {
         ? NaN
         : // eslint-disable-next-line no-undef
           BigInt(value);
+    case "integer": // not a target type for coercion, but can be inferred
     case "number": {
       return value === 0
         ? value
@@ -599,17 +594,12 @@ export function coerceToType(value, type) {
       return new Date(value);
     }
     case "array":
-      if (Array.isArray(value)) return value;
-      return [value];
     case "object":
-      // this will return true for everything except null, undefined, strings,
-      // numbers, boolean, and symbols, so may yield unexpected results.
-      if (typeof value === "object") return value;
-      return {value: value};
     case "buffer":
     case "other":
-    default:
       return value || value === 0 ? value : null;
+    default:
+      throw new Error(`Unable to coerce to type: ${type}`);
   }
 }
 

--- a/src/table.js
+++ b/src/table.js
@@ -866,7 +866,7 @@ export function inferSchema(source, columns = getAllKeys(source)) {
     // Chose the non-string, non-other type with the greatest count that is also
     // ≥90%; or if no such type meets that criterion, fallback to string if
     // ≥90%; and lastly fallback to other.
-    const minCount = colCount.defined * 0.9;
+    const minCount = Math.max(1, colCount.defined * 0.9);
     const type =
       greatest(types, (type) =>
         colCount[type] >= minCount ? colCount[type] : NaN

--- a/src/table.js
+++ b/src/table.js
@@ -586,7 +586,9 @@ export function coerceToType(value, type) {
     case "date": {
       if (value instanceof Date) return value;
       const trimValue = typeof value === "string" ? value.trim() : value;
-      return new Date(trimValue);
+      return value && /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))?([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/.test(trimValue)
+        ? new Date(trimValue)
+        : new Date("");
     }
     case "array":
     case "object":

--- a/src/table.js
+++ b/src/table.js
@@ -207,7 +207,8 @@ const loadTableDataSource = sourceCache(async (source, name) => {
     throw new Error(`unsupported file type: ${source.mimeType}`);
   }
   if (isArrowTable(source) || isArqueroTable(source)) return loadDuckDBClient(source, name);
-  if (arrayIsPrimitive(source)) return Array.from(source, (value) => ({value}));
+  if (isDataArray(source) && arrayIsPrimitive(source))
+    return Array.from(source, (value) => ({value}));
   return source;
 });
 

--- a/src/table.js
+++ b/src/table.js
@@ -869,7 +869,8 @@ export function inferSchema(source) {
         : "other";
     schema.push({
       name: col,
-      type: type
+      type: type,
+      inferred: type
     });
   }
   return schema;

--- a/src/table.js
+++ b/src/table.js
@@ -538,14 +538,14 @@ export function getTypeValidator(colType) {
   }
 }
 
-function coerceToType(value, type, options = {}) {
+export function coerceToType(value, type, options = {}) {
   const defaultValue = options.soft ? value : null;
   const numberDefault = defaultValue === null ? NaN : defaultValue;
   switch (type) {
     case "string":
       return value === "string"
         ? value.trim()
-        : value
+        : value || value === 0
         ? value.toString()
         : defaultValue;
     case "boolean":
@@ -557,8 +557,12 @@ function coerceToType(value, type, options = {}) {
     case "integer":
       return !value || isNaN(parseInt(value)) ? numberDefault : parseInt(value);
     case "bigint":
-      // eslint-disable-next-line no-undef
-      return !value || isNaN(value) ? numberDefault : BigInt(value);
+      return typeof value === "bigint"
+        ? value
+        : !value || isNaN(value)
+        ? numberDefault
+        // eslint-disable-next-line no-undef
+        : BigInt(value);
     case "number": {
       return !value || isNaN(value) ? numberDefault : Number(value);
     }
@@ -585,7 +589,7 @@ function coerceToType(value, type, options = {}) {
     }
     case "array":
       if (Array.isArray(value)) return value;
-      return Array.isArray(Array.from(value))
+      return value && Array.isArray(Array.from(value))
         ? Array.from(value)
         : defaultValue;
     case "buffer":

--- a/src/table.js
+++ b/src/table.js
@@ -851,7 +851,7 @@ function inferType(colValue) {
       else return "number";
     }
     else if (typedNonStrings.includes(type)) return type;
-    else return "other";
+    else if (value) return "other";
   } else {
     if (value === "true" || value === "false") return "boolean";
     else if (value && !isNaN(value)) {
@@ -860,6 +860,5 @@ function inferType(colValue) {
     } else if (/^\d+n$/.test(value)) return "bigint";
     else if (DATE_TEST.test(value)) return "date";
     else if (value) return "string";
-    else return "other";
   }
 }

--- a/src/table.js
+++ b/src/table.js
@@ -587,8 +587,8 @@ export function coerceToType(value, type) {
     case "date": {
       if (value instanceof Date || value == null) return value;
       if (typeof value === "number") return new Date(value);
-      if (typeof value === "string" && !value.trim()) return null;
       const trimValue = String(value).trim();
+      if (typeof value === "string" && !trimValue) return null;
       return new Date(DATE_TEST.test(trimValue) ? trimValue : NaN);
     }
     case "array":

--- a/src/table.js
+++ b/src/table.js
@@ -546,9 +546,10 @@ export function getTypeValidator(colType) {
 export function coerceToType(value, type, options = {}) {
   const defaultValue = options.soft ? value : null;
   const numberDefault = defaultValue === null ? NaN : defaultValue;
-  const stringValue = typeof value === "string" && !options.soft ? value.trim() : value;
+  const stringValue =
+    typeof value === "string" && !options.soft ? value.trim() : value;
   switch (type) {
-    case "string": 
+    case "string":
       return typeof value === "string"
         ? stringValue
         : value || value === 0
@@ -561,16 +562,27 @@ export function coerceToType(value, type, options = {}) {
         ? false
         : defaultValue;
     case "integer":
-      return !value || isNaN(parseInt(value)) ? numberDefault : parseInt(value);
+      return value === 0
+        ? value
+        : !value || isNaN(parseInt(value))
+        ? numberDefault
+        : parseInt(value);
     case "bigint":
       return typeof value === "bigint"
         ? value
+        : value === 0 || value === true || value === false
+        ? // eslint-disable-next-line no-undef
+          BigInt(value)
         : !value || isNaN(value) || !Number.isInteger(+value)
         ? numberDefault
-        // eslint-disable-next-line no-undef
-        : BigInt(value);
+        : // eslint-disable-next-line no-undef
+          BigInt(value);
     case "number": {
-      return !value || isNaN(value) ? numberDefault : Number(value);
+      return value === 0
+        ? value
+        : !value || isNaN(value)
+        ? numberDefault
+        : Number(value);
     }
     case "date": {
       if (value instanceof Date) return value;

--- a/src/table.js
+++ b/src/table.js
@@ -553,11 +553,13 @@ export function coerceToType(value, type) {
         ? value
         : String(value);
     case "boolean":
-      return value === true || stringValue === "true"
-        ? true
-        : value === false || stringValue === "false"
-        ? false
-        : null;
+      if (typeof value === "string") {
+        const trimValue = value.trim();
+        return trimValue === "true" ? true : trimValue === "false" ? false : null;
+      }
+      return typeof value === "boolean" || value == null
+        ? value
+        : Boolean(value);
     case "integer":
       return value === 0
         ? value

--- a/src/table.js
+++ b/src/table.js
@@ -557,13 +557,15 @@ const DATE_TEST = /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2}))|(\d{1,2})\/(\d{1,2})\/(\d
 export function coerceToType(value, type) {
   switch (type) {
     case "string":
-      return typeof value === "string" || value == null
-        ? value
-        : String(value);
+      return typeof value === "string" || value == null ? value : String(value);
     case "boolean":
       if (typeof value === "string") {
         const trimValue = value.trim();
-        return trimValue === "true" ? true : trimValue === "false" ? false : null;
+        return trimValue.toLowerCase() === "true"
+          ? true
+          : trimValue.toLowerCase() === "false"
+          ? false
+          : null;
       }
       return typeof value === "boolean" || value == null
         ? value
@@ -850,11 +852,11 @@ function inferType(colValue) {
     else if (type === "number") {
       if (Number.isInteger(+value)) return "integer";
       else return "number";
-    }
-    else if (typedNonStrings.includes(type)) return type;
+    } else if (typedNonStrings.includes(type)) return type;
     else if (value) return "other";
   } else {
-    if (value === "true" || value === "false") return "boolean";
+    if (value.toLowerCase() === "true" || value.toLowerCase() === "false")
+      return "boolean";
     else if (value && !isNaN(value)) {
       if (Number.isInteger(+value)) return "integer";
       else return "number";

--- a/src/table.js
+++ b/src/table.js
@@ -822,7 +822,7 @@ export function inferSchema(source, columns = getAllKeys(source)) {
     for (const col of columns) {
       if (!typeCounts[col]) typeCounts[col] = initKey();
       const type = typeof d[col];
-      const value = type === "string" ? d[col].trim() : d[col];
+      let value = d[col];
       if (type !== "string") {
         if (Array.isArray(value)) ++typeCounts[col].array;
         else if (value instanceof Date) ++typeCounts[col].date;
@@ -835,7 +835,8 @@ export function inferSchema(source, columns = getAllKeys(source)) {
         else if (type in typeCounts[col]) ++typeCounts[col][type];
         else if (value !== null && value !== undefined) ++typeCounts[col].other;
       } else {
-        if (value.toLowerCase() === "true" || value.toLowerCase() === "false") {
+        value = value.trim();
+        if (/^(true|false)$/i.test(value)) {
           ++typeCounts[col].string;
           ++typeCounts[col].boolean;
         } else if (value && !isNaN(value)) {

--- a/src/table.js
+++ b/src/table.js
@@ -546,17 +546,18 @@ export function getTypeValidator(colType) {
 export function coerceToType(value, type, options = {}) {
   const defaultValue = options.soft ? value : null;
   const numberDefault = defaultValue === null ? NaN : defaultValue;
+  const stringValue = typeof value === "string" && !options.soft ? value.trim() : value;
   switch (type) {
     case "string": 
       return typeof value === "string"
-        ? value.trim()
+        ? stringValue
         : value || value === 0
         ? value.toString()
         : defaultValue;
     case "boolean":
-      return value === true || value === "true"
+      return value === true || stringValue === "true"
         ? true
-        : value === false || value === "false"
+        : value === false || stringValue === "false"
         ? false
         : defaultValue;
     case "integer":
@@ -576,12 +577,12 @@ export function coerceToType(value, type, options = {}) {
       if (typeof value === "string") {
         let match;
         if (
-          (match = value.match(
+          (match = stringValue.match(
             /^([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)?(T\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/
           ))
         ) {
           if (fixTz && !!match[4] && !match[7])
-            value = value.replace(/-/g, "/").replace(/T/, " ");
+            value = stringValue.replace(/-/g, "/").replace(/T/, " ");
         }
       }
       // Invalid Date objects are still instances of Date, but they return true

--- a/src/table.js
+++ b/src/table.js
@@ -546,6 +546,8 @@ export function getTypeValidator(colType) {
 export function coerceToType(value, type) {
   const stringValue = typeof value === "string" ? value.trim() : value;
   switch (type) {
+    case "raw":
+      return value;
     case "string":
       return typeof value === "string"
         ? stringValue

--- a/src/table.js
+++ b/src/table.js
@@ -618,14 +618,14 @@ export function coerceToType(value, type) {
 export function __table(source, operations) {
   const input = source;
   let {schema, columns} = source;
+  let primitive = arrayIsPrimitive(source);
+  if (primitive) source = Array.from(source, (value) => ({value}));
   let inferredSchema = false;
   if (!isQueryResultSetSchema(schema)) {
-    if (arrayIsPrimitive(source)) schema = inferFromPrimitive(source, columns);
+    if (primitive) schema = inferSchema(source, ["value"]);
     else schema = inferSchema(source, columns);
     inferredSchema = true;
   }
-  let primitive = arrayIsPrimitive(source);
-  if (primitive) source = Array.from(source, (value) => ({value}));
   // Combine column types from schema with user-selected types in operations
   const types = new Map(schema.map(({name, type}) => [name, type]));
   if (operations.type) {
@@ -809,13 +809,6 @@ function getAllKeys(rows) {
     }
   }
   return Array.from(keys);
-}
-
-export function inferFromPrimitive(source) {
-  const primitiveSource = source.map((d) => {
-    return {value: d};
-  });
-  return inferSchema(primitiveSource, ["value"]);
 }
 
 export function inferSchema(source, columns = getAllKeys(source)) {

--- a/src/table.js
+++ b/src/table.js
@@ -815,9 +815,8 @@ export function inferFromPrimitive(source) {
   const primitiveSource = source.map((d) => {
     return {value: d};
   });
- return inferSchema(primitiveSource, ["value"]);
+  return inferSchema(primitiveSource, ["value"]);
 }
-
 
 export function inferSchema(source, columns = getAllKeys(source)) {
   const schema = [];
@@ -862,7 +861,10 @@ export function inferSchema(source, columns = getAllKeys(source)) {
     }
   }
   for (const col in typeCounts) {
-    let type = greatest(Object.keys(typeCounts[col]), (d) => typeCounts[col][d]);
+    let type = greatest(
+      Object.keys(typeCounts[col]),
+      (d) => typeCounts[col][d]
+    );
     // If over 90% of the sampled data counted as this type, use it. Otherwise,
     // use "other."
     type =

--- a/src/table.js
+++ b/src/table.js
@@ -566,15 +566,11 @@ export function coerceToType(value, type) {
         ? value
         : Boolean(value);
     case "bigint":
-      return typeof value === "bigint"
+      return typeof value === "bigint" || value == null
         ? value
-        : value === 0 || value === true || value === false
-        ? // eslint-disable-next-line no-undef
-          BigInt(value)
-        : !value || isNaN(value) || !Number.isInteger(+value)
-        ? NaN
-        : // eslint-disable-next-line no-undef
-          BigInt(value);
+        : Number.isInteger(typeof value === "string" && !value ? NaN : +value)
+        ? BigInt(value) // eslint-disable-line no-undef
+        : undefined;
     case "integer": // not a target type for coercion, but can be inferred
     case "number": {
       return typeof value === "number"
@@ -586,7 +582,7 @@ export function coerceToType(value, type) {
     case "date": {
       if (value instanceof Date) return value;
       const trimValue = typeof value === "string" ? value.trim() : value;
-      return value && /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2})?)|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))?([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/.test(trimValue)
+      return value && /^(([-+]\d{2})?\d{4}(-\d{2}(-\d{2}))|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))?([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/.test(trimValue)
         ? new Date(trimValue)
         : new Date("");
     }

--- a/src/table.js
+++ b/src/table.js
@@ -764,12 +764,12 @@ export function __table(source, operations) {
   return source;
 }
 
-function coerceRow(object, types) {
-  let coerced = {};
-  for (var key in object) {
-    const type = types.get(key);
-    const value = object[key];
-    coerced[key] = coerceToType(value, type);
+function coerceRow(object, types, schema) {
+  const coerced = {};
+  for (const col of schema) {
+    const type = types.get(col.name);
+    const value = object[col.name];
+    coerced[col.name] = type === "raw" ? value : coerceToType(value, type);
   }
   return coerced;
 }

--- a/src/table.js
+++ b/src/table.js
@@ -583,11 +583,10 @@ export function coerceToType(value, type) {
         : Number(value);
     }
     case "date": {
-      if (value instanceof Date) return value;
-      const trimValue = typeof value === "string" ? value.trim() : value;
-      return DATE_TEST.test(trimValue)
-        ? new Date(trimValue)
-        : new Date("");
+      if (value instanceof Date || value == null) return value;
+      if (typeof value === "number") return new Date(value);
+      const trimValue = String(value).trim();
+      return new Date(DATE_TEST.test(trimValue) ? trimValue : NaN);
     }
     case "array":
     case "object":

--- a/src/table.js
+++ b/src/table.js
@@ -816,10 +816,11 @@ export function inferSchema(source) {
         else if (value !== null && value !== undefined) typeCounts[key].other++;
       } else {
         if (value === "true" || value === "false") typeCounts[key].boolean++;
-        else if (!isNaN(value)) {
+        else if (value && !isNaN(value)) {
           if (/^-?[0-9]+$/.test(value)) typeCounts[key].integer++;
           else typeCounts[key].number++;
         } else if (
+          value &&
           value.match(
             /^(([-+]\d{2})?\d{4}(-\d{1,2}(-\d{1,2})?)|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))?([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/
           )
@@ -827,7 +828,7 @@ export function inferSchema(source) {
           typeCounts[key].date++;
         // the long regex accepts dates in the form of ISOString and
         // LocaleDateString, with or without times
-        else typeCounts[key].string++;
+        else if (value) typeCounts[key].string++;
       }
     }
   }

--- a/src/table.js
+++ b/src/table.js
@@ -207,6 +207,7 @@ const loadTableDataSource = sourceCache(async (source, name) => {
     throw new Error(`unsupported file type: ${source.mimeType}`);
   }
   if (isArrowTable(source) || isArqueroTable(source)) return loadDuckDBClient(source, name);
+  if (arrayIsPrimitive(source)) return Array.from(source, (value) => ({value}));
   return source;
 });
 
@@ -610,12 +611,9 @@ export function coerceToType(value, type) {
 export function __table(source, operations) {
   const input = source;
   let {schema, columns} = source;
-  let primitive = arrayIsPrimitive(source);
-  if (primitive) source = Array.from(source, (value) => ({value}));
   let inferredSchema = false;
   if (!isQueryResultSetSchema(schema)) {
-    if (primitive) schema = inferSchema(source, ["value"]);
-    else schema = inferSchema(source, columns);
+    schema = inferSchema(source, columns);
     inferredSchema = true;
   }
   // Combine column types from schema with user-selected types in operations
@@ -746,7 +744,6 @@ export function __table(source, operations) {
       Object.fromEntries(operations.select.columns.map((c) => [c, d[c]]))
     );
   }
-  if (primitive) source = source.map((d) => d.value);
   if (source !== input) {
     if (schema) source.schema = schema;
     if (columns) source.columns = columns;

--- a/src/table.js
+++ b/src/table.js
@@ -585,7 +585,7 @@ export function coerceToType(value, type, options = {}) {
         }
       }
       // Invalid Date objects are still instances of Date, but they return true
-      // from isNaN(). If we are "soft-coercing," we want to return the original
+      // from isNaN(). If we are soft-coercing, we want to return the original
       // value for invalid dates. Otherwise, if a date is invalid, return an
       // Invalid Date object.
       const date = new Date(value);
@@ -624,11 +624,11 @@ export function __table(source, operations) {
   if (operations.type) {
     for (const {name, type} of operations.type) {
       types.set(name, type);
-      source = source.map(d => coerceRow(d, types));
       // update schema with user-selected type
       const colIndex = schema.findIndex((col) => col.name === name);
       if (colIndex > -1) schema[colIndex] = {name, type};
     }
+    source = source.map(d => coerceRow(d, types));
   }
   // Coerce data according to new schema, unless that happened due to
   // operations.type, above. If coercing for the first time here, perform with

--- a/src/table.js
+++ b/src/table.js
@@ -68,14 +68,16 @@ function objectHasEnumerableKeys(value) {
 function isQueryResultSetSchema(schemas) {
   return (
     Array.isArray(schemas) &&
-    schemas.every(
-      (s) => s && typeof s.name === "string" && typeof s.type === "string"
-    )
+    schemas.every(isColumnSchema)
   );
 }
 
 function isQueryResultSetColumns(columns) {
   return (Array.isArray(columns) && columns.every((name) => typeof name === "string"));
+}
+
+function isColumnSchema(schema) {
+  return schema && typeof schema.name === "string" && typeof schema.type === "string";
 }
 
 // Returns true if the value represents an array of primitives (i.e., a
@@ -547,11 +549,9 @@ export function coerceToType(value, type) {
   const stringValue = typeof value === "string" ? value.trim() : value;
   switch (type) {
     case "string":
-      return typeof value === "string"
-        ? stringValue
-        : value || value === 0
-        ? value.toString()
-        : null;
+      return typeof value === "string" || value == null
+        ? value
+        : String(value);
     case "boolean":
       return value === true || stringValue === "true"
         ? true

--- a/src/table.js
+++ b/src/table.js
@@ -579,7 +579,7 @@ export function coerceToType(value, type) {
     case "number": {
       return typeof value === "number"
         ? value
-        : value == null || value === ""
+        : value == null || (typeof value === "string" && !value)
         ? NaN
         : Number(value);
     }

--- a/src/table.js
+++ b/src/table.js
@@ -796,7 +796,7 @@ function initKey() {
     string: 0,
     array: 0,
     object: 0,
-    bigint: 0, // TODO for csv, tsv?
+    bigint: 0,
     buffer: 0
   };
 }
@@ -834,7 +834,8 @@ export function inferSchema(source) {
         else if (value && !isNaN(value)) {
           if (Number.isInteger(+value)) typeCounts[key].integer++;
           else typeCounts[key].number++;
-        } else if (
+        } else if (/^\d+n$/.test(value)) typeCounts[key].bigint++;
+        else if (
           value &&
           value.match(
             /^(([-+]\d{2})?\d{4}(-\d{1,2}(-\d{1,2})?)|(\d{1,2})\/(\d{1,2})\/(\d{2,4}))?([T ]\d{2}:\d{2}(:\d{2}(\.\d{3})?)?(Z|[-+]\d{2}:\d{2})?)?$/

--- a/src/table.js
+++ b/src/table.js
@@ -546,8 +546,6 @@ export function getTypeValidator(colType) {
 export function coerceToType(value, type) {
   const stringValue = typeof value === "string" ? value.trim() : value;
   switch (type) {
-    case "raw":
-      return value;
     case "string":
       return typeof value === "string"
         ? stringValue
@@ -637,12 +635,11 @@ export function __table(source, operations) {
       const colIndex = schema.findIndex((col) => col.name === name);
       if (colIndex > -1) schema[colIndex] = {...schema[colIndex], type};
     }
-    source = source.map(d => coerceRow(d, types));
-  }
-  // Coerce data according to new schema, unless that happened due to
-  // operations.type, above. 
-  if (inferredSchema && !operations.type) {
-    source = source.map(d => coerceRow(d, types));
+    source = source.map(d => coerceRow(d, types, schema));
+  } else if (inferredSchema) {
+    // Coerce data according to new schema, unless that happened due to
+    // operations.type, above. 
+    source = source.map(d => coerceRow(d, types, schema));
   }
   for (const {type, operands} of operations.filter) {
     const [{value: column}] = operands;

--- a/src/table.js
+++ b/src/table.js
@@ -585,6 +585,7 @@ export function coerceToType(value, type) {
     case "date": {
       if (value instanceof Date || value == null) return value;
       if (typeof value === "number") return new Date(value);
+      if (typeof value === "string" && !value) return null;
       const trimValue = String(value).trim();
       return new Date(DATE_TEST.test(trimValue) ? trimValue : NaN);
     }

--- a/src/table.js
+++ b/src/table.js
@@ -620,10 +620,10 @@ export function coerceToType(value, type) {
 export function __table(source, operations) {
   const input = source;
   let {schema, columns} = source;
-  let newlyInferred = false;
+  let inferredSchema = false;
   if (!schema || !isQueryResultSetSchema(schema)) {
     schema = inferSchema(source);
-    newlyInferred = true;
+    inferredSchema = true;
   }
   let primitive = arrayIsPrimitive(source);
   if (primitive) source = Array.from(source, (value) => ({value}));
@@ -641,7 +641,7 @@ export function __table(source, operations) {
   }
   // Coerce data according to new schema, unless that happened due to
   // operations.type, above. 
-  if (newlyInferred && !operations.type) {
+  if (inferredSchema && !operations.type) {
     source = source.map(d => coerceRow(d, types));
   }
   for (const {type, operands} of operations.filter) {

--- a/src/table.js
+++ b/src/table.js
@@ -791,7 +791,27 @@ function initKey() {
   };
 }
 
+// We need to show *all* keys present in the array of Objects
+function getAllKeys(rows) {
+  const keys = new Set();
+  for (const row of rows) {
+    // avoid crash if row is null or undefined
+    if (row) {
+      // only enumerable properties
+      for (const key in row) {
+        // only own properties
+        if (Object.prototype.hasOwnProperty.call(row, key)) {
+          // unique properties, in the order they appear
+          keys.add(key);
+        }
+      }
+    }
+  }
+  return Array.from(keys);
+}
+
 export function inferSchema(source) {
+  const allKeys = getAllKeys(source);
   const schema = [];
   const sampleSize = 100;
   let sample = source.slice(0, sampleSize);
@@ -799,10 +819,11 @@ export function inferSchema(source) {
     sample = sample.map((d) => {
       return {value: d};
     });
+    allKeys.push("value");
   }
   const typeCounts = {};
   for (const d of sample) {
-    for (const key in d) {
+    for (const key of allKeys) {
       if (!typeCounts[key]) typeCounts[key] = initKey();
       // for json and sqlite, we already have some types, but for csv and tsv, all
       // columns are strings here.

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1014,6 +1014,34 @@ describe("inferSchema", () => {
       [{name: "x", type: "string", inferred: "string"}]
     );
   });
+
+  it("infers boolean-ish strings and strings as booleans", () => {
+    assert.deepStrictEqual(
+      inferSchema(["true", "false", "true", "false", "true", "false", "true", "false", "true", "false", "pants on fire"].map((x) => ({x}))),
+      [{name: "x", type: "boolean", inferred: "boolean"}]
+    );
+  });
+
+  it("infers booleans and strings as booleans", () => {
+    assert.deepStrictEqual(
+      inferSchema([true, false, true, false, true, false, true, false, true, false, "pants on fire"].map((x) => ({x}))),
+      [{name: "x", type: "boolean", inferred: "boolean"}]
+    );
+  });
+
+  it("infers numbers and strings as numbers", () => {
+    assert.deepStrictEqual(
+      inferSchema([0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, 0.1, 0.2, "x"].map((x) => ({x}))),
+      [{name: "x", type: "number", inferred: "number"}]
+    );
+  });
+
+  it("infers number-ish strings and strings as numbers", () => {
+    assert.deepStrictEqual(
+      inferSchema(["0.1", "0.2", "0.1", "0.2", "0.1", "0.2", "0.1", "0.2", "0.1", "0.2", "x"].map((x) => ({x}))),
+      [{name: "x", type: "number", inferred: "number"}]
+    );
+  });
 });
 
 describe("coerceToType", () => {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1126,6 +1126,8 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType(null, "date"), null);
     assert.deepStrictEqual(coerceToType("", "date"), null);
     assert.deepStrictEqual(coerceToType(" ", "date"), null);
+    assert.deepStrictEqual(coerceToType({toString: () => " "}, "date").toString(), invalidDate.toString());
+    assert.deepStrictEqual(coerceToType({toString: () => "2020-01-01"}, "date"), new Date("2020-01-01"));
   });
 
   it("coerces to string", () => {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1039,7 +1039,7 @@ describe("coerceToType", () => {
       new Date("2022-01-01T12:34:00Z")
     );
     assert.deepStrictEqual(
-      coerceToType("B", "date").toString(),
+      coerceToType("", "date").toString(),
       invalidDate.toString()
     );
     assert.deepStrictEqual(
@@ -1047,7 +1047,15 @@ describe("coerceToType", () => {
       invalidDate.toString()
     );
     assert.deepStrictEqual(
+      coerceToType(undefined, "date").toString(),
+      invalidDate.toString()
+    );
+    assert.deepStrictEqual(
       coerceToType(null, "date").toString(),
+      invalidDate.toString()
+    );
+    assert.deepStrictEqual(
+      coerceToType(true, "date").toString(),
       invalidDate.toString()
     );
     assert.deepStrictEqual(

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1,7 +1,6 @@
 import {
   coerceToType,
   getTypeValidator,
-  inferFromPrimitive,
   inferSchema,
   makeQueryTemplate,
   __table
@@ -610,7 +609,7 @@ describe("__table", () => {
       expectedPrimitive
     );
     const expectedUint32Array = [1];
-    expectedUint32Array.schema = [{name: "value", type: "other", inferred: "other"}];
+    expectedUint32Array.schema = [{name: "value", type: "integer", inferred: "integer"}];
     assert.deepStrictEqual(
       __table(Uint32Array.of(1, 2, 3), {
         ...EMPTY_TABLE_DATA.operations,
@@ -965,17 +964,6 @@ describe("inferSchema", () => {
     assert.deepStrictEqual(
       inferSchema([{a: Symbol("a")}, {a: Symbol("b")}]),
       [{name: "a", type: "other", inferred: "other"}]
-    );
-  });
-
-  it("infers from arrays of primitives", () => {
-    assert.deepStrictEqual(
-      inferFromPrimitive(["true", "false"]),
-      [{name: "value", type: "boolean", inferred: "boolean"}]
-    );
-    assert.deepStrictEqual(
-      inferFromPrimitive([1, 2, 3]),
-      [{name: "value", type: "integer", inferred: "integer"}]
     );
   });
 });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1005,7 +1005,7 @@ describe("coerceToType", () => {
     );
     // with whitespace
     assert.deepStrictEqual(
-      coerceToType("12/12/2020  ", "date", {soft: true}),
+      coerceToType("12/12/2020  ", "date"),
       new Date("12/12/2020")
     );
     assert.deepStrictEqual(
@@ -1090,7 +1090,7 @@ describe("coerceToType", () => {
     );
     assert.deepStrictEqual(coerceToType([1,2,3], "raw"), [1,2,3]);
     assert.deepStrictEqual(
-      coerceToType("12/12/2020  ", "raw", {soft: true}), "12/12/2020  "
+      coerceToType("12/12/2020  ", "raw"), "12/12/2020  "
     );
     assert.deepStrictEqual(coerceToType(null, "raw"), null);
     assert.deepStrictEqual(coerceToType(NaN, "raw"), NaN);

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1070,11 +1070,13 @@ describe("coerceToType", () => {
   it("coerces to bigint", () => {
     assert.deepStrictEqual(coerceToType("32", "bigint"), 32n);
     assert.deepStrictEqual(coerceToType(32n, "bigint"), 32n);
+    assert.deepStrictEqual(coerceToType(1.1, "bigint"), NaN);
     assert.deepStrictEqual(coerceToType("A", "bigint"), NaN);
   });
 
   it("soft coerces to bigint", () => {
     assert.deepStrictEqual(coerceToType("32", "bigint", {soft: true}), 32n);
+    assert.deepStrictEqual(coerceToType(1.1, "bigint", {soft: true}), 1.1);
     assert.deepStrictEqual(coerceToType("A", "bigint", {soft: true}), "A");
   });
 

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -935,7 +935,7 @@ describe("inferSchema", () => {
   it("infers dates", () => {
     assert.deepStrictEqual(
       inferSchema(
-        [{a: "1/2/20"}, {a: "2020-11-12 12:23:00"}, {a: new Date()}, {a: "2020-1-12"}]
+        [{a: "1/2/20"}, {a: "2020-11-12 12:23:00"}, {a: new Date()}, {a: "2020-01-12"}]
       ),
       [{name: "a", type: "date", inferred: "date"}]
     );

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -590,43 +590,6 @@ describe("__table", () => {
     );
   });
 
-  it("__table filter primitive lte + gte", () => {
-    const expectedPrimitive = [1];
-    expectedPrimitive.schema = [{name: "value", type: "integer", inferred: "integer"}];
-    assert.deepStrictEqual(
-      __table([1, 2, 3], {
-        ...EMPTY_TABLE_DATA.operations,
-        filter: [
-          {
-            type: "eq",
-            operands: [
-              {type: "column", value: "value"},
-              {type: "resolved", value: 1}
-            ]
-          }
-        ]
-      }),
-      expectedPrimitive
-    );
-    const expectedUint32Array = [1];
-    expectedUint32Array.schema = [{name: "value", type: "integer", inferred: "integer"}];
-    assert.deepStrictEqual(
-      __table(Uint32Array.of(1, 2, 3), {
-        ...EMPTY_TABLE_DATA.operations,
-        filter: [
-          {
-            type: "eq",
-            operands: [
-              {type: "column", value: "value"},
-              {type: "resolved", value: 1}
-            ]
-          }
-        ]
-      }),
-      expectedUint32Array
-    );
-  });
-
   it("__table filter eq date", () => {
     const operationsEquals = {
       ...EMPTY_TABLE_DATA.operations,

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1073,11 +1073,11 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType(0, "bigint"), 0n);
     assert.deepStrictEqual(coerceToType(false, "bigint"), 0n);
     assert.deepStrictEqual(coerceToType(true, "bigint"), 1n);
-    assert.deepStrictEqual(coerceToType(null, "bigint"), NaN);
-    assert.deepStrictEqual(coerceToType(undefined, "bigint"), NaN);
-    assert.deepStrictEqual(coerceToType(1.1, "bigint"), NaN);
-    assert.deepStrictEqual(coerceToType("A", "bigint"), NaN);
-    assert.deepStrictEqual(coerceToType(NaN, "bigint"), NaN);
+    assert.deepStrictEqual(coerceToType(null, "bigint"), null);
+    assert.deepStrictEqual(coerceToType(undefined, "bigint"), undefined);
+    assert.deepStrictEqual(coerceToType(1.1, "bigint"), undefined);
+    assert.deepStrictEqual(coerceToType("A", "bigint"), undefined);
+    assert.deepStrictEqual(coerceToType(NaN, "bigint"), undefined);
   });
 
   it("coerces to array", () => {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1163,7 +1163,7 @@ describe("coerceToType", () => {
 
   it("coerces to array", () => {
     // "array" is not a target type for coercion, but can be inferred.
-    assert.deepStrictEqual(coerceToType([1, 2, 3], "array"), [1,2,3]);
+    assert.deepStrictEqual(coerceToType([1, 2, 3], "array"), [1, 2, 3]);
     assert.deepStrictEqual(coerceToType(null, "array"), null);
     assert.deepStrictEqual(coerceToType(undefined, "array"), undefined);
   });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -788,17 +788,33 @@ describe("__table", () => {
       ...EMPTY_TABLE_DATA.operations,
       names: [{column: "a", name: "nameA"}]
     };
-    assert.deepStrictEqual(__table(source, operations), [{nameA: 1, b: 2, c: 3}, {nameA: 2, b: 4, c: 6}, {nameA: 3, b: 6, c: 9}]);
+    const expected = [
+      {nameA: 1, b: 2, c: 3},
+      {nameA: 2, b: 4, c: 6},
+      {nameA: 3, b: 6, c: 9}
+    ];
+    expected.schema = [
+      {name: "nameA", type: "integer", inferred: "integer"},
+      {name: "b", type: "integer", inferred: "integer"},
+      {name: "c", type: "integer", inferred: "integer"}
+    ];
+    assert.deepStrictEqual(__table(source, operations), expected);
     source.columns = ["a", "b", "c"];
-    assert.deepStrictEqual(
-      __table(source, operations).columns,
-      ["nameA", "b", "c"]
-    );
-    source.schema = [{name: "a", type: "number"}, {name: "b", type: "number"}, {name: "c", type: "number"}];
-    assert.deepStrictEqual(
-      __table(source, operations).schema,
-      [{name: "nameA", type: "number"}, {name: "b", type: "number"}, {name: "c", type: "number"}]
-    );
+    assert.deepStrictEqual(__table(source, operations).columns, [
+      "nameA",
+      "b",
+      "c"
+    ]);
+    source.schema = [
+      {name: "a", type: "integer", inferred: "integer"},
+      {name: "b", type: "integer", inferred: "integer"},
+      {name: "c", type: "integer", inferred: "integer"}
+    ];
+    assert.deepStrictEqual(__table(source, operations).schema, [
+      {name: "nameA", type: "integer", inferred: "integer"},
+      {name: "b", type: "integer", inferred: "integer"},
+      {name: "c", type: "integer", inferred: "integer"}
+    ]);
   });
 });
 

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1012,12 +1012,15 @@ describe("coerceToType", () => {
 
   it("coerces to boolean", () => {
     assert.deepStrictEqual(coerceToType("true", "boolean"), true);
-    assert.deepStrictEqual(coerceToType("true   ", "boolean"), true);
+    assert.deepStrictEqual(coerceToType("True   ", "boolean"), true);
     assert.deepStrictEqual(coerceToType(true, "boolean"), true);
-    assert.deepStrictEqual(coerceToType("false", "boolean"), false);
+    assert.deepStrictEqual(coerceToType("False", "boolean"), false);
     assert.deepStrictEqual(coerceToType(false, "boolean"), false);
     assert.deepStrictEqual(coerceToType(1, "boolean"), true);
+    assert.deepStrictEqual(coerceToType(2, "boolean"), true);
     assert.deepStrictEqual(coerceToType(0, "boolean"), false);
+    assert.deepStrictEqual(coerceToType({}, "boolean"), true);
+    assert.deepStrictEqual(coerceToType(new Date(), "boolean"), true);
     assert.deepStrictEqual(coerceToType("A", "boolean"), null);
     assert.deepStrictEqual(coerceToType(null, "boolean"), null);
     assert.deepStrictEqual(coerceToType(undefined, "boolean"), undefined);

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -609,7 +609,7 @@ describe("__table", () => {
       expectedPrimitive
     );
     const expectedUint32Array = [1];
-    expectedUint32Array.schema = [];
+    expectedUint32Array.schema = [{name: "value", type: "other"}];
     assert.deepStrictEqual(
       __table(Uint32Array.of(1, 2, 3), {
         ...EMPTY_TABLE_DATA.operations,
@@ -990,6 +990,8 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType("true", "boolean"), true);
     assert.deepStrictEqual(coerceToType("true   ", "boolean"), true);
     assert.deepStrictEqual(coerceToType(true, "boolean"), true);
+    assert.deepStrictEqual(coerceToType("false", "boolean"), false);
+    assert.deepStrictEqual(coerceToType(false, "boolean"), false);
     assert.deepStrictEqual(coerceToType("A", "boolean"), null);
     assert.deepStrictEqual(coerceToType(null, "boolean"), null);
     assert.deepStrictEqual(coerceToType(undefined, "boolean"), null);

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -690,7 +690,7 @@ describe("__table", () => {
       sort: [{column: "a", direction: "desc"}]
     };
     const expectedDesc = [
-      {a: 20}, {a: 10}, {a: 5}, {a: 1}, {a: null}, {a: null}, {a: null}, {a: null}
+      {a: 20}, {a: 10}, {a: 5}, {a: 1}, {a: null}, {a: undefined}, {a: NaN}, {a: null}
     ];
     expectedDesc.schema = [{name: "a", type: "other", inferred: "other"}];
     assert.deepStrictEqual(
@@ -702,7 +702,7 @@ describe("__table", () => {
       sort: [{column: "a", direction: "asc"}]
     };
     const expectedAsc = [
-      {a: 1}, {a: 5}, {a: 10}, {a: 20}, {a: null}, {a: null}, {a: null}, {a: null}
+      {a: 1}, {a: 5}, {a: 10}, {a: 20}, {a: null}, {a: undefined}, {a: NaN}, {a: null}
     ];
     expectedAsc.schema = [{name: "a", type: "other", inferred: "other"}];
     assert.deepStrictEqual(
@@ -1003,6 +1003,7 @@ describe("coerceToType", () => {
   it("coerces to number", () => {
     assert.deepStrictEqual(coerceToType("1.2", "number"), 1.2);
     assert.deepStrictEqual(coerceToType(0, "number"), 0);
+    assert.deepStrictEqual(coerceToType("", "number"), NaN);
     assert.deepStrictEqual(coerceToType("A", "number"), NaN);
     assert.deepStrictEqual(coerceToType(null, "number"), NaN);
     assert.deepStrictEqual(coerceToType(undefined, "number"), NaN);
@@ -1062,20 +1063,6 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType(NaN, "string"), "NaN");
   });
 
-  it("coerces to array", () => {
-    // "array" is not a target type for coercion, but can be inferred.
-    assert.deepStrictEqual(coerceToType([1,2,3], "array"), [1,2,3]);
-    assert.deepStrictEqual(coerceToType(null, "array"), null);
-    assert.deepStrictEqual(coerceToType(undefined, "array"), null);
-  });
-
-  it("coerces to object", () => {
-    // "object" is not a target type for coercion, but can be inferred.
-    assert.deepStrictEqual(coerceToType({a: 1, b: 2}, "object"), {a: 1, b: 2});
-    assert.deepStrictEqual(coerceToType(null, "object"), null);
-    assert.deepStrictEqual(coerceToType(undefined, "object"), null);
-  });
-
   it("coerces to bigint", () => {
     assert.deepStrictEqual(coerceToType("32", "bigint"), 32n);
     assert.deepStrictEqual(coerceToType(32n, "bigint"), 32n);
@@ -1089,6 +1076,20 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType(NaN, "bigint"), NaN);
   });
 
+  it("coerces to array", () => {
+    // "array" is not a target type for coercion, but can be inferred.
+    assert.deepStrictEqual(coerceToType([1,2,3], "array"), [1,2,3]);
+    assert.deepStrictEqual(coerceToType(null, "array"), null);
+    assert.deepStrictEqual(coerceToType(undefined, "array"), undefined);
+  });
+
+  it("coerces to object", () => {
+    // "object" is not a target type for coercion, but can be inferred.
+    assert.deepStrictEqual(coerceToType({a: 1, b: 2}, "object"), {a: 1, b: 2});
+    assert.deepStrictEqual(coerceToType(null, "object"), null);
+    assert.deepStrictEqual(coerceToType(undefined, "object"), undefined);
+  });
+
   it("coerces to buffer", () => {
     // "buffer" is not a target type for coercion, but can be inferred.
     assert.deepStrictEqual(
@@ -1097,7 +1098,7 @@ describe("coerceToType", () => {
     );
     assert.deepStrictEqual(coerceToType("A", "buffer"), "A");
     assert.deepStrictEqual(coerceToType(null, "buffer"), null);
-    assert.deepStrictEqual(coerceToType(undefined, "buffer"), null);
+    assert.deepStrictEqual(coerceToType(undefined, "buffer"), undefined);
   });
 
   it("coerces to other", () => {
@@ -1105,7 +1106,7 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType(0, "other"), 0);
     assert.deepStrictEqual(coerceToType("a", "other"), "a");
     assert.deepStrictEqual(coerceToType(null, "other"), null);
-    assert.deepStrictEqual(coerceToType(undefined, "other"), null);
+    assert.deepStrictEqual(coerceToType(undefined, "other"), undefined);
   });
 
   // Note: if type is "raw", coerceToType() will not be called. Instead, values

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1039,10 +1039,6 @@ describe("coerceToType", () => {
       new Date("2022-01-01T12:34:00Z")
     );
     assert.deepStrictEqual(
-      coerceToType("", "date").toString(),
-      invalidDate.toString()
-    );
-    assert.deepStrictEqual(
       coerceToType({a: 1}, "date").toString(),
       invalidDate.toString()
     );
@@ -1060,6 +1056,7 @@ describe("coerceToType", () => {
     );
     assert.deepStrictEqual(coerceToType(undefined, "date"), undefined);
     assert.deepStrictEqual(coerceToType(null, "date"), null);
+    assert.deepStrictEqual(coerceToType("", "date"), null);
   });
 
   it("coerces to string", () => {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1024,7 +1024,7 @@ describe("coerceToType", () => {
   });
 
   it("coerces to date", () => {
-    const invalidDate = new Date("a");
+    const invalidDate = new Date("");
     assert.deepStrictEqual(
       coerceToType("12/12/2020", "date"),
       new Date("12/12/2020")
@@ -1048,7 +1048,11 @@ describe("coerceToType", () => {
     );
     assert.deepStrictEqual(
       coerceToType(null, "date").toString(),
-      new Date(null).toString()
+      invalidDate.toString()
+    );
+    assert.deepStrictEqual(
+      coerceToType("2020-1-12", "date").toString(),
+      invalidDate.toString()
     );
   });
 

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -974,18 +974,16 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType("10", "integer"), 10);
     assert.deepStrictEqual(coerceToType(0, "integer"), 0);
     assert.deepStrictEqual(coerceToType("A", "integer"), NaN);
+    assert.deepStrictEqual(coerceToType(null, "integer"), NaN);
   });
 
   it("coerces to number", () => {
     assert.deepStrictEqual(coerceToType("1.2", "number"), 1.2);
     assert.deepStrictEqual(coerceToType(0, "number"), 0);
     assert.deepStrictEqual(coerceToType("A", "number"), NaN);
-  });
-
-  it("soft coerces to number", () => {
-    assert.deepStrictEqual(coerceToType("1.2", "number", {soft: true}), 1.2);
-    assert.deepStrictEqual(coerceToType(0, "number", {soft: true}), 0);
-    assert.deepStrictEqual(coerceToType("a", "number", {soft: true}), "a");
+    assert.deepStrictEqual(coerceToType(null, "number"), NaN);
+    assert.deepStrictEqual(coerceToType(undefined, "number"), NaN);
+    assert.deepStrictEqual(coerceToType({a: 1}, "number"), NaN);
   });
 
   it("coerces to boolean", () => {
@@ -993,12 +991,8 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType("true   ", "boolean"), true);
     assert.deepStrictEqual(coerceToType(true, "boolean"), true);
     assert.deepStrictEqual(coerceToType("A", "boolean"), null);
-  });
-
-  it("soft coerces to boolean", () => {
-    assert.deepStrictEqual(coerceToType("false", "boolean", {soft: true}), false);
-    assert.deepStrictEqual(coerceToType("a", "boolean", {soft: true}), "a");
-    assert.deepStrictEqual(coerceToType("true   ", "boolean", {soft: true}), "true   ");
+    assert.deepStrictEqual(coerceToType(null, "boolean"), null);
+    assert.deepStrictEqual(coerceToType(undefined, "boolean"), null);
   });
 
   it("coerces to date", () => {
@@ -1024,22 +1018,9 @@ describe("coerceToType", () => {
       coerceToType({a: 1}, "date").toString(),
       invalidDate.toString()
     );
-  });
-
-  it("soft coerces to date", () => {
     assert.deepStrictEqual(
-      coerceToType("12/12/2020", "date", {soft: true}),
-      new Date("12/12/2020")
-    );
-    // with whitespace
-    assert.deepStrictEqual(
-      coerceToType("12/12/2020  ", "date", {soft: true}),
-      new Date("12/12/2020")
-    );
-    assert.deepStrictEqual(coerceToType("B", "date", {soft: true}), "B");
-    assert.deepStrictEqual(
-      coerceToType({a: 1}, "date", {soft: true}).toString(),
-      "[object Object]"
+      coerceToType(null, "date").toString(),
+      new Date(null).toString()
     );
   });
 
@@ -1050,15 +1031,7 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType(0, "string"), "0");
     assert.deepStrictEqual(coerceToType(null, "string"), null);
     assert.deepStrictEqual(coerceToType(undefined, "string"), null);
-  });
-
-  it("soft coerces to string", () => {
-    assert.deepStrictEqual(coerceToType(true, "string", {soft: true}), "true");
-    assert.deepStrictEqual(coerceToType(null, "string", {soft: true}), null);
-    assert.deepStrictEqual(
-      coerceToType(undefined, "string", {soft: true}),
-      undefined
-    );
+    assert.deepStrictEqual(coerceToType(NaN, "string"), null);
   });
 
   it("coerces to array", () => {
@@ -1068,28 +1041,11 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType(undefined, "array"), [undefined]);
   });
 
-  it("soft coerces to array", () => {
-    assert.deepStrictEqual(coerceToType([1,2,3], "array", {soft: true}), [1,2,3]);
-    assert.deepStrictEqual(
-      coerceToType(undefined, "array", {soft: true}),
-      [undefined]
-    );
-  });
-
   it("coerces to object", () => {
     assert.deepStrictEqual(coerceToType("true", "object"), {value: "true"});
     assert.deepStrictEqual(coerceToType({a: 1, b: 2}, "object"), {a: 1, b: 2});
     assert.deepStrictEqual(coerceToType(null, "object"), null);
     assert.deepStrictEqual(coerceToType(undefined, "object"), {value: undefined});
-  });
-
-  it("soft coerces to object", () => {
-    assert.deepStrictEqual(coerceToType("true", "object", {soft: true}), {value: "true"});
-    assert.deepStrictEqual(coerceToType(null, "object", {soft: true}), null);
-    assert.deepStrictEqual(
-      coerceToType(undefined, "object", {soft: true}),
-      {value: undefined}
-    );
   });
 
   it("coerces to bigint", () => {
@@ -1102,12 +1058,7 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType(undefined, "bigint"), NaN);
     assert.deepStrictEqual(coerceToType(1.1, "bigint"), NaN);
     assert.deepStrictEqual(coerceToType("A", "bigint"), NaN);
-  });
-
-  it("soft coerces to bigint", () => {
-    assert.deepStrictEqual(coerceToType("32", "bigint", {soft: true}), 32n);
-    assert.deepStrictEqual(coerceToType(1.1, "bigint", {soft: true}), 1.1);
-    assert.deepStrictEqual(coerceToType("A", "bigint", {soft: true}), "A");
+    assert.deepStrictEqual(coerceToType(NaN, "bigint"), NaN);
   });
 
   it("coerces to buffer", () => {
@@ -1116,28 +1067,14 @@ describe("coerceToType", () => {
       new ArrayBuffer()
     );
     assert.deepStrictEqual(coerceToType("A", "buffer"), "A");
+    assert.deepStrictEqual(coerceToType(null, "buffer"), null);
     assert.deepStrictEqual(coerceToType(undefined, "buffer"), null);
-  });
-
-  it("soft coerces to buffer", () => {
-    assert.deepStrictEqual(coerceToType("A", "buffer"), "A");
-    assert.deepStrictEqual(
-      coerceToType(undefined, "buffer", {soft: true}),
-      undefined
-    );
   });
 
   it("coerces to other", () => {
     assert.deepStrictEqual(coerceToType(0, "other"), 0);
     assert.deepStrictEqual(coerceToType("a", "other"), "a");
+    assert.deepStrictEqual(coerceToType(null, "other"), null);
     assert.deepStrictEqual(coerceToType(undefined, "other"), null);
-  });
-
-  it("soft coerces to other", () => {
-    assert.deepStrictEqual(coerceToType("a", "other", {soft: true}), "a");
-    assert.deepStrictEqual(
-      coerceToType(undefined, "other", {soft: true}),
-      undefined
-    );
   });
 });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1028,12 +1028,13 @@ describe("coerceToType", () => {
 
   it("coerces to string", () => {
     assert.deepStrictEqual(coerceToType(true, "string"), "true");
+    assert.deepStrictEqual(coerceToType(false, "string"), "false");
     assert.deepStrictEqual(coerceToType(10, "string"), "10");
     assert.deepStrictEqual(coerceToType({a: 1}, "string"), "[object Object]");
     assert.deepStrictEqual(coerceToType(0, "string"), "0");
     assert.deepStrictEqual(coerceToType(null, "string"), null);
-    assert.deepStrictEqual(coerceToType(undefined, "string"), null);
-    assert.deepStrictEqual(coerceToType(NaN, "string"), null);
+    assert.deepStrictEqual(coerceToType(undefined, "string"), undefined);
+    assert.deepStrictEqual(coerceToType(NaN, "string"), "NaN");
   });
 
   it("coerces to array", () => {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -985,6 +985,10 @@ describe("inferSchema", () => {
       inferSchema([{a: Symbol("a")}, {a: Symbol("b")}]),
       [{name: "a", type: "other", inferred: "other"}]
     );
+    assert.deepStrictEqual(
+      inferSchema([{a: null}, {a: null}]),
+      [{name: "a", type: "other", inferred: "other"}]
+    );
   });
 
   it("infers mixed integers and numbers as numbers", () => {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -992,9 +992,11 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType(true, "boolean"), true);
     assert.deepStrictEqual(coerceToType("false", "boolean"), false);
     assert.deepStrictEqual(coerceToType(false, "boolean"), false);
+    assert.deepStrictEqual(coerceToType(1, "boolean"), true);
+    assert.deepStrictEqual(coerceToType(0, "boolean"), false);
     assert.deepStrictEqual(coerceToType("A", "boolean"), null);
     assert.deepStrictEqual(coerceToType(null, "boolean"), null);
-    assert.deepStrictEqual(coerceToType(undefined, "boolean"), null);
+    assert.deepStrictEqual(coerceToType(undefined, "boolean"), undefined);
   });
 
   it("coerces to date", () => {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -965,13 +965,22 @@ describe("inferSchema", () => {
 });
 
 describe("coerceToType", () => {
+  it("coerces to integer", () => {
+    assert.deepStrictEqual(coerceToType("1.2", "integer"), 1);
+    assert.deepStrictEqual(coerceToType("10", "integer"), 10);
+    assert.deepStrictEqual(coerceToType(0, "integer"), 0);
+    assert.deepStrictEqual(coerceToType("A", "integer"), NaN);
+  });
+
   it("coerces to number", () => {
     assert.deepStrictEqual(coerceToType("1.2", "number"), 1.2);
+    assert.deepStrictEqual(coerceToType(0, "number"), 0);
     assert.deepStrictEqual(coerceToType("A", "number"), NaN);
   });
 
   it("soft coerces to number", () => {
     assert.deepStrictEqual(coerceToType("1.2", "number", {soft: true}), 1.2);
+    assert.deepStrictEqual(coerceToType(0, "number", {soft: true}), 0);
     assert.deepStrictEqual(coerceToType("a", "number", {soft: true}), "a");
   });
 
@@ -1082,6 +1091,11 @@ describe("coerceToType", () => {
   it("coerces to bigint", () => {
     assert.deepStrictEqual(coerceToType("32", "bigint"), 32n);
     assert.deepStrictEqual(coerceToType(32n, "bigint"), 32n);
+    assert.deepStrictEqual(coerceToType(0, "bigint"), 0n);
+    assert.deepStrictEqual(coerceToType(false, "bigint"), 0n);
+    assert.deepStrictEqual(coerceToType(true, "bigint"), 1n);
+    assert.deepStrictEqual(coerceToType(null, "bigint"), NaN);
+    assert.deepStrictEqual(coerceToType(undefined, "bigint"), NaN);
     assert.deepStrictEqual(coerceToType(1.1, "bigint"), NaN);
     assert.deepStrictEqual(coerceToType("A", "bigint"), NaN);
   });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1080,20 +1080,8 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType(undefined, "other"), null);
   });
 
-  it("coerces to raw", () => {
-    assert.deepStrictEqual(coerceToType(0, "raw"), 0);
-    assert.deepStrictEqual(coerceToType("a", "raw"), "a");
-    assert.deepStrictEqual(coerceToType(32n, "raw"), 32n);
-    assert.deepStrictEqual(
-      coerceToType(new ArrayBuffer(), "raw"),
-      new ArrayBuffer()
-    );
-    assert.deepStrictEqual(coerceToType([1,2,3], "raw"), [1,2,3]);
-    assert.deepStrictEqual(
-      coerceToType("12/12/2020  ", "raw"), "12/12/2020  "
-    );
-    assert.deepStrictEqual(coerceToType(null, "raw"), null);
-    assert.deepStrictEqual(coerceToType(NaN, "raw"), NaN);
-    assert.deepStrictEqual(coerceToType(undefined, "raw"), undefined);
-  });
+  // Note: if type is "raw", coerceToType() will not be called. Instead, values
+  // will be returned from coerceRow().
+  // it("coerces to raw", () => {
+  // });
 });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1079,4 +1079,21 @@ describe("coerceToType", () => {
     assert.deepStrictEqual(coerceToType(null, "other"), null);
     assert.deepStrictEqual(coerceToType(undefined, "other"), null);
   });
+
+  it("coerces to raw", () => {
+    assert.deepStrictEqual(coerceToType(0, "raw"), 0);
+    assert.deepStrictEqual(coerceToType("a", "raw"), "a");
+    assert.deepStrictEqual(coerceToType(32n, "raw"), 32n);
+    assert.deepStrictEqual(
+      coerceToType(new ArrayBuffer(), "raw"),
+      new ArrayBuffer()
+    );
+    assert.deepStrictEqual(coerceToType([1,2,3], "raw"), [1,2,3]);
+    assert.deepStrictEqual(
+      coerceToType("12/12/2020  ", "raw", {soft: true}), "12/12/2020  "
+    );
+    assert.deepStrictEqual(coerceToType(null, "raw"), null);
+    assert.deepStrictEqual(coerceToType(NaN, "raw"), NaN);
+    assert.deepStrictEqual(coerceToType(undefined, "raw"), undefined);
+  });
 });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1058,33 +1058,33 @@ describe("coerceToType", () => {
   });
 
   it("coerces to array", () => {
-    assert.deepStrictEqual(coerceToType("true", "array"), ["t", "r", "u", "e"]);
+    assert.deepStrictEqual(coerceToType("true", "array"), ["true"]);
     assert.deepStrictEqual(coerceToType([1,2,3], "array"), [1,2,3]);
-    assert.deepStrictEqual(coerceToType(null, "array"), null);
-    assert.deepStrictEqual(coerceToType(undefined, "array"), null);
+    assert.deepStrictEqual(coerceToType(null, "array"), [null]);
+    assert.deepStrictEqual(coerceToType(undefined, "array"), [undefined]);
   });
 
   it("soft coerces to array", () => {
     assert.deepStrictEqual(coerceToType([1,2,3], "array", {soft: true}), [1,2,3]);
     assert.deepStrictEqual(
       coerceToType(undefined, "array", {soft: true}),
-      undefined
+      [undefined]
     );
   });
 
   it("coerces to object", () => {
-    assert.deepStrictEqual(coerceToType("true", "object"), "true");
+    assert.deepStrictEqual(coerceToType("true", "object"), {value: "true"});
     assert.deepStrictEqual(coerceToType({a: 1, b: 2}, "object"), {a: 1, b: 2});
     assert.deepStrictEqual(coerceToType(null, "object"), null);
-    assert.deepStrictEqual(coerceToType(undefined, "object"), null);
+    assert.deepStrictEqual(coerceToType(undefined, "object"), {value: undefined});
   });
 
   it("soft coerces to object", () => {
-    assert.deepStrictEqual(coerceToType("true", "object", {soft: true}), "true");
+    assert.deepStrictEqual(coerceToType("true", "object", {soft: true}), {value: "true"});
     assert.deepStrictEqual(coerceToType(null, "object", {soft: true}), null);
     assert.deepStrictEqual(
       coerceToType(undefined, "object", {soft: true}),
-      undefined
+      {value: undefined}
     );
   });
 

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -911,7 +911,7 @@ describe("inferSchema", () => {
         ]
       ),
       [
-        {name: "a", type: "other", inferred: "other"},
+        {name: "a", type: "integer", inferred: "integer"},
         {name: "b", type: "integer", inferred: "integer"},
         {name: "c", type: "integer", inferred: "integer"}
       ]

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -886,8 +886,8 @@ describe("inferSchema", () => {
       inferSchema(
         [
           {a: 1, b: 2, c: 3},
-          {a: 2, b: 4, c: 6},
-          {a: 3, b: 6, c: 9}
+          {a: "", b: 4, c: 6},
+          {a: "", b: 6, c: 9}
         ]
       ),
       [

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1001,6 +1001,13 @@ describe("inferSchema", () => {
     );
   });
 
+  it("infers mixed integers and strings as integers", () => {
+    assert.deepStrictEqual(
+      inferSchema(["0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "x"].map((x) => ({x}))),
+      [{name: "x", type: "integer", inferred: "integer"}]
+    );
+  });
+
   it("infers boolean-ish strings and strings as strings", () => {
     assert.deepStrictEqual(
       inferSchema(["true", "false", "pants on fire"].map((x) => ({x}))),

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -455,9 +455,9 @@ describe("__table", () => {
       {a: 3, b: 6, c: 9}
     ];
     source.schema = [
-      {name: "a", type: "integer"},
-      {name: "b", type: "integer"},
-      {name: "c", type: "integer"}
+      {name: "a", type: "integer", inferred: "integer"},
+      {name: "b", type: "integer", inferred: "integer"},
+      {name: "c", type: "integer", inferred: "integer"}
     ];
   });
 
@@ -489,7 +489,7 @@ describe("__table", () => {
       select: {columns: ["a"]}
     };
     const expectedSelected = [{a: 1}, {a: 2}, {a: 3}];
-    expectedSelected.schema = [{name: "a", type: "integer"}];
+    expectedSelected.schema = [{name: "a", type: "integer", inferred: "integer"}];
     assert.deepStrictEqual(
       __table(source, operationsSelectedColumns),
       expectedSelected
@@ -592,7 +592,7 @@ describe("__table", () => {
 
   it("__table filter primitive lte + gte", () => {
     const expectedPrimitive = [1];
-    expectedPrimitive.schema = [{name: "value", type: "integer"}];
+    expectedPrimitive.schema = [{name: "value", type: "integer", inferred: "integer"}];
     assert.deepStrictEqual(
       __table([1, 2, 3], {
         ...EMPTY_TABLE_DATA.operations,
@@ -609,7 +609,7 @@ describe("__table", () => {
       expectedPrimitive
     );
     const expectedUint32Array = [1];
-    expectedUint32Array.schema = [{name: "value", type: "other"}];
+    expectedUint32Array.schema = [{name: "value", type: "other", inferred: "other"}];
     assert.deepStrictEqual(
       __table(Uint32Array.of(1, 2, 3), {
         ...EMPTY_TABLE_DATA.operations,
@@ -646,7 +646,7 @@ describe("__table", () => {
       {a: new Date("2021-01-03")}
     ];
     const expected = [{a: new Date("2021-01-02")}];
-    expected.schema = [{name: "a", type: "date"}];
+    expected.schema = [{name: "a", type: "date", inferred: "date"}];
     assert.deepStrictEqual(__table(source, operationsEquals), expected);
   });
 
@@ -706,7 +706,7 @@ describe("__table", () => {
     const expectedDesc = [
       {a: 20}, {a: 10}, {a: 5}, {a: 1}, {a: null}, {a: null}, {a: null}, {a: null}
     ];
-    expectedDesc.schema = [{name: "a", type: "other"}];
+    expectedDesc.schema = [{name: "a", type: "other", inferred: "other"}];
     assert.deepStrictEqual(
       __table(sourceWithMissing, operationsDesc),
       expectedDesc
@@ -718,7 +718,7 @@ describe("__table", () => {
     const expectedAsc = [
       {a: 1}, {a: 5}, {a: 10}, {a: 20}, {a: null}, {a: null}, {a: null}, {a: null}
     ];
-    expectedAsc.schema = [{name: "a", type: "other"}];
+    expectedAsc.schema = [{name: "a", type: "other", inferred: "other"}];
     assert.deepStrictEqual(
       __table(sourceWithMissing, operationsAsc),
       expectedAsc
@@ -783,16 +783,16 @@ describe("__table", () => {
       ["a", "b", "c"]
     );
     source.schema = [
-      {name: "a", type: "number"},
-      {name: "b", type: "number"},
-      {name: "c", type: "number"}
+      {name: "a", type: "number", inferred: "number"},
+      {name: "b", type: "number", inferred: "number"},
+      {name: "c", type: "number", inferred: "number"}
     ];
     assert.deepStrictEqual(
       __table(source, EMPTY_TABLE_DATA.operations).schema,
       [
-        {name: "a", type: "number"},
-        {name: "b", type: "number"},
-        {name: "c", type: "number"}
+        {name: "a", type: "number", inferred: "number"},
+        {name: "b", type: "number", inferred: "number"},
+        {name: "c", type: "number", inferred: "number"}
       ]
     );
   });
@@ -891,9 +891,9 @@ describe("inferSchema", () => {
         ]
       ),
       [
-        {name: "a", type: "other"},
-        {name: "b", type: "integer"},
-        {name: "c", type: "integer"}
+        {name: "a", type: "other", inferred: "other"},
+        {name: "b", type: "integer", inferred: "integer"},
+        {name: "c", type: "integer", inferred: "integer"}
       ]
     );
   });
@@ -901,14 +901,14 @@ describe("inferSchema", () => {
   it("infers numbers", () => {
     assert.deepStrictEqual(
       inferSchema([{a: 1.2}, {a: 3.4}, {a: 5.67}]),
-      [{name: "a", type: "number"}]
+      [{name: "a", type: "number", inferred: "number"}]
     );
   });
 
   it("infers booleans", () => {
     assert.deepStrictEqual(
       inferSchema([{a: "true"}, {a: false}, {a: "false"}]),
-      [{name: "a", type: "boolean"}]
+      [{name: "a", type: "boolean", inferred: "boolean"}]
     );
   });
 
@@ -917,53 +917,53 @@ describe("inferSchema", () => {
       inferSchema(
         [{a: "1/2/20"}, {a: "2020-11-12 12:23:00"}, {a: new Date()}, {a: "2020-1-12"}]
       ),
-      [{name: "a", type: "date"}]
+      [{name: "a", type: "date", inferred: "date"}]
     );
   });
 
   it("infers strings", () => {
     assert.deepStrictEqual(
       inferSchema([{a: "cat"}, {a: "dog"}, {a: "1,000"}, {a: "null"}]),
-      [{name: "a", type: "string"}]
+      [{name: "a", type: "string", inferred: "string"}]
     );
   });
 
   it("infers arrays", () => {
     assert.deepStrictEqual(
       inferSchema([{a: ["cat"]}, {a: ["dog"]}, {a: []}]),
-      [{name: "a", type: "array"}]
+      [{name: "a", type: "array", inferred: "array"}]
     );
   });
 
   it("infers objects", () => {
     assert.deepStrictEqual(
       inferSchema([{a: {d: ["cat"]}}, {a: {d: "dog"}}, {a: {d: 12}}]),
-      [{name: "a", type: "object"}]
+      [{name: "a", type: "object", inferred: "object"}]
     );
   });
 
   it("infers bigints", () => {
     assert.deepStrictEqual(
       inferSchema([{a: 10n}, {a: 22n}, {a: 1n}]),
-      [{name: "a", type: "bigint"}]
+      [{name: "a", type: "bigint", inferred: "bigint"}]
     );
     assert.deepStrictEqual(
       inferSchema([{a: "10n"}, {a: "22n"}, {a: "0n"}]),
-      [{name: "a", type: "bigint"}]
+      [{name: "a", type: "bigint", inferred: "bigint"}]
     );
   });
 
   it("infers buffers", () => {
     assert.deepStrictEqual(
       inferSchema([{a: new ArrayBuffer()}, {a: new ArrayBuffer()}]),
-      [{name: "a", type: "buffer"}]
+      [{name: "a", type: "buffer", inferred: "buffer"}]
     );
   });
 
   it("infers other", () => {
     assert.deepStrictEqual(
       inferSchema([{a: Symbol("a")}, {a: Symbol("b")}]),
-      [{name: "a", type: "other"}]
+      [{name: "a", type: "other", inferred: "other"}]
     );
   });
 });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -947,6 +947,10 @@ describe("inferSchema", () => {
       inferSchema([{a: 10n}, {a: 22n}, {a: 22}, {a: null}]),
       [{name: "a", type: "bigint"}]
     );
+    assert.deepStrictEqual(
+      inferSchema([{a: "10n"}, {a: "22n"}, {a: "0n"}, {a: null}]),
+      [{name: "a", type: "bigint"}]
+    );
   });
 
   it("infers buffers", () => {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1,6 +1,7 @@
 import {
   coerceToType,
   getTypeValidator,
+  inferFromPrimitive,
   inferSchema,
   makeQueryTemplate,
   __table
@@ -964,6 +965,17 @@ describe("inferSchema", () => {
     assert.deepStrictEqual(
       inferSchema([{a: Symbol("a")}, {a: Symbol("b")}]),
       [{name: "a", type: "other", inferred: "other"}]
+    );
+  });
+
+  it("infers from arrays of primitives", () => {
+    assert.deepStrictEqual(
+      inferFromPrimitive(["true", "false"]),
+      [{name: "value", type: "boolean", inferred: "boolean"}]
+    );
+    assert.deepStrictEqual(
+      inferFromPrimitive([1, 2, 3]),
+      [{name: "value", type: "integer", inferred: "integer"}]
     );
   });
 });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -690,9 +690,9 @@ describe("__table", () => {
       sort: [{column: "a", direction: "desc"}]
     };
     const expectedDesc = [
-      {a: 20}, {a: 10}, {a: 5}, {a: 1}, {a: null}, {a: undefined}, {a: NaN}, {a: null}
+      {a: 20}, {a: 10}, {a: 5}, {a: 1}, {a: NaN}, {a: NaN}, {a: NaN}, {a: NaN}
     ];
-    expectedDesc.schema = [{name: "a", type: "other", inferred: "other"}];
+    expectedDesc.schema = [{name: "a", type: "number", inferred: "number"}];
     assert.deepStrictEqual(
       __table(sourceWithMissing, operationsDesc),
       expectedDesc
@@ -702,9 +702,9 @@ describe("__table", () => {
       sort: [{column: "a", direction: "asc"}]
     };
     const expectedAsc = [
-      {a: 1}, {a: 5}, {a: 10}, {a: 20}, {a: null}, {a: undefined}, {a: NaN}, {a: null}
+      {a: 1}, {a: 5}, {a: 10}, {a: 20}, {a: NaN}, {a: NaN}, {a: NaN}, {a: NaN}
     ];
-    expectedAsc.schema = [{name: "a", type: "other", inferred: "other"}];
+    expectedAsc.schema = [{name: "a", type: "number", inferred: "number"}];
     assert.deepStrictEqual(
       __table(sourceWithMissing, operationsAsc),
       expectedAsc
@@ -984,6 +984,27 @@ describe("inferSchema", () => {
     assert.deepStrictEqual(
       inferSchema([{a: Symbol("a")}, {a: Symbol("b")}]),
       [{name: "a", type: "other", inferred: "other"}]
+    );
+  });
+
+  it("infers mixed integers and numbers as numbers", () => {
+    assert.deepStrictEqual(
+      inferSchema([0.1, 0.2, 0.3, 0.4, 0.5, 1, 2, 3, 4, 5].map((x) => ({x}))),
+      [{name: "x", type: "number", inferred: "number"}]
+    );
+  });
+
+  it("infers mixed integers and NaNs as numbers", () => {
+    assert.deepStrictEqual(
+      inferSchema([NaN, NaN, NaN, 1, 2, 3, 4, 5].map((x) => ({x}))),
+      [{name: "x", type: "number", inferred: "number"}]
+    );
+  });
+
+  it("infers boolean-ish strings and strings as strings", () => {
+    assert.deepStrictEqual(
+      inferSchema(["true", "false", "pants on fire"].map((x) => ({x}))),
+      [{name: "x", type: "string", inferred: "string"}]
     );
   });
 });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1024,7 +1024,7 @@ describe("coerceToType", () => {
   });
 
   it("coerces to date", () => {
-    const invalidDate = new Date("");
+    const invalidDate = new Date(NaN);
     assert.deepStrictEqual(
       coerceToType("12/12/2020", "date"),
       new Date("12/12/2020")
@@ -1047,14 +1047,6 @@ describe("coerceToType", () => {
       invalidDate.toString()
     );
     assert.deepStrictEqual(
-      coerceToType(undefined, "date").toString(),
-      invalidDate.toString()
-    );
-    assert.deepStrictEqual(
-      coerceToType(null, "date").toString(),
-      invalidDate.toString()
-    );
-    assert.deepStrictEqual(
       coerceToType(true, "date").toString(),
       invalidDate.toString()
     );
@@ -1062,6 +1054,12 @@ describe("coerceToType", () => {
       coerceToType("2020-1-12", "date").toString(),
       invalidDate.toString()
     );
+    assert.deepStrictEqual(
+      coerceToType(1675356739000, "date"),
+      new Date(1675356739000)
+    );
+    assert.deepStrictEqual(coerceToType(undefined, "date"), undefined);
+    assert.deepStrictEqual(coerceToType(null, "date"), null);
   });
 
   it("coerces to string", () => {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -970,7 +970,10 @@ describe("inferSchema", () => {
 
 describe("coerceToType", () => {
   it("coerces to integer", () => {
-    assert.deepStrictEqual(coerceToType("1.2", "integer"), 1);
+    // "integer" is not a target type for coercion, but can be inferred. So it
+    // will be handled as an alias for "number".
+    assert.deepStrictEqual(coerceToType("1.2", "integer"), 1.2);
+    assert.deepStrictEqual(coerceToType(1.2, "integer"), 1.2);
     assert.deepStrictEqual(coerceToType("10", "integer"), 10);
     assert.deepStrictEqual(coerceToType(0, "integer"), 0);
     assert.deepStrictEqual(coerceToType("A", "integer"), NaN);
@@ -1040,17 +1043,17 @@ describe("coerceToType", () => {
   });
 
   it("coerces to array", () => {
-    assert.deepStrictEqual(coerceToType("true", "array"), ["true"]);
+    // "array" is not a target type for coercion, but can be inferred.
     assert.deepStrictEqual(coerceToType([1,2,3], "array"), [1,2,3]);
-    assert.deepStrictEqual(coerceToType(null, "array"), [null]);
-    assert.deepStrictEqual(coerceToType(undefined, "array"), [undefined]);
+    assert.deepStrictEqual(coerceToType(null, "array"), null);
+    assert.deepStrictEqual(coerceToType(undefined, "array"), null);
   });
 
   it("coerces to object", () => {
-    assert.deepStrictEqual(coerceToType("true", "object"), {value: "true"});
+    // "object" is not a target type for coercion, but can be inferred.
     assert.deepStrictEqual(coerceToType({a: 1, b: 2}, "object"), {a: 1, b: 2});
     assert.deepStrictEqual(coerceToType(null, "object"), null);
-    assert.deepStrictEqual(coerceToType(undefined, "object"), {value: undefined});
+    assert.deepStrictEqual(coerceToType(undefined, "object"), null);
   });
 
   it("coerces to bigint", () => {
@@ -1067,6 +1070,7 @@ describe("coerceToType", () => {
   });
 
   it("coerces to buffer", () => {
+    // "buffer" is not a target type for coercion, but can be inferred.
     assert.deepStrictEqual(
       coerceToType(new ArrayBuffer(), "buffer"),
       new ArrayBuffer()
@@ -1077,6 +1081,7 @@ describe("coerceToType", () => {
   });
 
   it("coerces to other", () => {
+    // "other" is not a target type for coercion, but can be inferred.
     assert.deepStrictEqual(coerceToType(0, "other"), 0);
     assert.deepStrictEqual(coerceToType("a", "other"), "a");
     assert.deepStrictEqual(coerceToType(null, "other"), null);
@@ -1085,6 +1090,4 @@ describe("coerceToType", () => {
 
   // Note: if type is "raw", coerceToType() will not be called. Instead, values
   // will be returned from coerceRow().
-  // it("coerces to raw", () => {
-  // });
 });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -704,9 +704,9 @@ describe("__table", () => {
       sort: [{column: "a", direction: "desc"}]
     };
     const expectedDesc = [
-      {a: 20}, {a: 10}, {a: 5}, {a: 1}, {a: NaN}, {a: undefined}, {a: NaN}, {a: NaN}
+      {a: 20}, {a: 10}, {a: 5}, {a: 1}, {a: null}, {a: null}, {a: null}, {a: null}
     ];
-    expectedDesc.schema = [{name: "a", type: "integer"}];
+    expectedDesc.schema = [{name: "a", type: "other"}];
     assert.deepStrictEqual(
       __table(sourceWithMissing, operationsDesc),
       expectedDesc
@@ -716,9 +716,9 @@ describe("__table", () => {
       sort: [{column: "a", direction: "asc"}]
     };
     const expectedAsc = [
-      {a: 1}, {a: 5}, {a: 10}, {a: 20}, {a: NaN}, {a: undefined}, {a: NaN}, {a: NaN}
+      {a: 1}, {a: 5}, {a: 10}, {a: 20}, {a: null}, {a: null}, {a: null}, {a: null}
     ];
-    expectedAsc.schema = [{name: "a", type: "integer"}];
+    expectedAsc.schema = [{name: "a", type: "other"}];
     assert.deepStrictEqual(
       __table(sourceWithMissing, operationsAsc),
       expectedAsc
@@ -891,7 +891,7 @@ describe("inferSchema", () => {
         ]
       ),
       [
-        {name: "a", type: "integer"},
+        {name: "a", type: "other"},
         {name: "b", type: "integer"},
         {name: "c", type: "integer"}
       ]
@@ -907,7 +907,7 @@ describe("inferSchema", () => {
 
   it("infers booleans", () => {
     assert.deepStrictEqual(
-      inferSchema([{a: "true"}, {a: false}, {a: "false"}, {a: null}]),
+      inferSchema([{a: "true"}, {a: false}, {a: "false"}]),
       [{name: "a", type: "boolean"}]
     );
   });
@@ -915,7 +915,7 @@ describe("inferSchema", () => {
   it("infers dates", () => {
     assert.deepStrictEqual(
       inferSchema(
-        [{a: "1/2/20"}, {a: "2020-11-12 12:23:00"}, {a: new Date()}, {a: null}]
+        [{a: "1/2/20"}, {a: "2020-11-12 12:23:00"}, {a: new Date()}, {a: "2020-1-12"}]
       ),
       [{name: "a", type: "date"}]
     );
@@ -923,46 +923,46 @@ describe("inferSchema", () => {
 
   it("infers strings", () => {
     assert.deepStrictEqual(
-      inferSchema([{a: "cat"}, {a: "dog"}, {a: "1,000"}, {a: null}]),
+      inferSchema([{a: "cat"}, {a: "dog"}, {a: "1,000"}, {a: "null"}]),
       [{name: "a", type: "string"}]
     );
   });
 
   it("infers arrays", () => {
     assert.deepStrictEqual(
-      inferSchema([{a: ["cat"]}, {a: ["dog"]}, {a: []}, {a: null}]),
+      inferSchema([{a: ["cat"]}, {a: ["dog"]}, {a: []}]),
       [{name: "a", type: "array"}]
     );
   });
 
   it("infers objects", () => {
     assert.deepStrictEqual(
-      inferSchema([{a: {d: ["cat"]}}, {a: {d: "dog"}}, {a: {d: 12}}, {a: null}]),
+      inferSchema([{a: {d: ["cat"]}}, {a: {d: "dog"}}, {a: {d: 12}}]),
       [{name: "a", type: "object"}]
     );
   });
 
   it("infers bigints", () => {
     assert.deepStrictEqual(
-      inferSchema([{a: 10n}, {a: 22n}, {a: 22}, {a: null}]),
+      inferSchema([{a: 10n}, {a: 22n}, {a: 1n}]),
       [{name: "a", type: "bigint"}]
     );
     assert.deepStrictEqual(
-      inferSchema([{a: "10n"}, {a: "22n"}, {a: "0n"}, {a: null}]),
+      inferSchema([{a: "10n"}, {a: "22n"}, {a: "0n"}]),
       [{name: "a", type: "bigint"}]
     );
   });
 
   it("infers buffers", () => {
     assert.deepStrictEqual(
-      inferSchema([{a: new ArrayBuffer()}, {a: new ArrayBuffer()}, {a: null}]),
+      inferSchema([{a: new ArrayBuffer()}, {a: new ArrayBuffer()}]),
       [{name: "a", type: "buffer"}]
     );
   });
 
   it("infers other", () => {
     assert.deepStrictEqual(
-      inferSchema([{a: Symbol("a")}, {a: Symbol("b")}, {a: null}]),
+      inferSchema([{a: Symbol("a")}, {a: Symbol("b")}]),
       [{name: "a", type: "other"}]
     );
   });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -977,6 +977,7 @@ describe("coerceToType", () => {
 
   it("coerces to boolean", () => {
     assert.deepStrictEqual(coerceToType("true", "boolean"), true);
+    assert.deepStrictEqual(coerceToType("true   ", "boolean"), true);
     assert.deepStrictEqual(coerceToType(true, "boolean"), true);
     assert.deepStrictEqual(coerceToType("A", "boolean"), null);
   });
@@ -984,12 +985,18 @@ describe("coerceToType", () => {
   it("soft coerces to boolean", () => {
     assert.deepStrictEqual(coerceToType("false", "boolean", {soft: true}), false);
     assert.deepStrictEqual(coerceToType("a", "boolean", {soft: true}), "a");
+    assert.deepStrictEqual(coerceToType("true   ", "boolean", {soft: true}), "true   ");
   });
 
   it("coerces to date", () => {
     const invalidDate = new Date("a");
     assert.deepStrictEqual(
       coerceToType("12/12/2020", "date"),
+      new Date("12/12/2020")
+    );
+    // with whitespace
+    assert.deepStrictEqual(
+      coerceToType("12/12/2020  ", "date", {soft: true}),
       new Date("12/12/2020")
     );
     assert.deepStrictEqual(
@@ -1009,6 +1016,11 @@ describe("coerceToType", () => {
   it("soft coerces to date", () => {
     assert.deepStrictEqual(
       coerceToType("12/12/2020", "date", {soft: true}),
+      new Date("12/12/2020")
+    );
+    // with whitespace
+    assert.deepStrictEqual(
+      coerceToType("12/12/2020  ", "date", {soft: true}),
       new Date("12/12/2020")
     );
     assert.deepStrictEqual(coerceToType("B", "date", {soft: true}), "B");


### PR DESCRIPTION
Resolves https://github.com/observablehq/observablehq/issues/9862 and https://github.com/observablehq/observablehq/issues/9673

In this inference approach, we take a sample (currently the first 100 rows), and for each column, count how many times we encounter each possible data type. Then, if > 90% of the sampled values conform to that type, we take the most frequently encountered type as the column's type. If not, we use type "other."

These changes include some support for upcoming [column type assertions](https://github.com/observablehq/observablehq/pull/10133), but for the purposes of this PR, I'm testing against main. 

https://user-images.githubusercontent.com/111310561/214719295-8326f325-879b-4b8a-9d9f-2397b28951de.mov


