### PR TITLE
Rename type to types

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -618,8 +618,8 @@ export function __table(source, operations) {
   }
   // Combine column types from schema with user-selected types in operations
   const types = new Map(schema.map(({name, type}) => [name, type]));
-  if (operations.type) {
-    for (const {name, type} of operations.type) {
+  if (operations.types) {
+    for (const {name, type} of operations.types) {
       types.set(name, type);
       // update schema with user-selected type
       if (schema === input.schema) schema = schema.slice(); // copy on write

--- a/src/table.js
+++ b/src/table.js
@@ -629,7 +629,7 @@ export function __table(source, operations) {
     source = source.map(d => coerceRow(d, types, schema));
   } else if (inferredSchema) {
     // Coerce data according to new schema, unless that happened due to
-    // operations.type, above.
+    // operations.types, above.
     source = source.map(d => coerceRow(d, types, schema));
   }
   for (const {type, operands} of operations.filter) {


### PR DESCRIPTION
This PR renames the key `.type` to `.types` on the incoming `operations` argument for compatibility with the data structure on Observablehq. 