### PR TITLE
Increase accumulateQuery debounce to 150ms

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -287,7 +287,7 @@ async function* accumulateQuery(queryRequest) {
   values.schema = queryResponse.schema;
   try {
     for await (const rows of queryResponse.readRows()) {
-      if (performance.now() - then > 10 && values.length > 0) {
+      if (performance.now() - then > 150 && values.length > 0) {
         yield values;
         then = performance.now();
       }


### PR DESCRIPTION
An attempt to address the problem of slow cells downstream of streaming data sources (laid out in https://github.com/observablehq/observablehq/issues/10193).

With fast database clients, I saw a bit of a noticeable difference in streaming speed, but I don't feel like it's enough to be a problem.

#### 10ms debounce (before)

https://user-images.githubusercontent.com/6464196/218569409-ae621b88-cb8e-45c9-9d9d-016601fbfb84.mov

#### 150ms debounce (after)

https://user-images.githubusercontent.com/6464196/218569436-c06006ad-9284-4bc4-b53d-0ee8fe07cc23.mov

