### PR TITLE
Load tabular data files for chart cells

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -169,6 +169,7 @@ export const __query = Object.assign(
 
 export async function loadDataSource(source, mode, name) {
   switch (mode) {
+    case "chart":
     case "table": return loadTableDataSource(source, name);
     case "sql": return loadSqlDataSource(source, name);
   }


### PR DESCRIPTION
This resolves an error where chart cells were fetching the table schema for a CSV, TSV, JSON, or SQLite file and receiving no columns back.