### PR TITLE
Export inferSchema

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,5 +9,6 @@ export {
   isDataArray,
   isDatabaseClient,
   __table as applyDataTableOperations,
-  getTypeValidator
+  getTypeValidator,
+  inferSchema
 } from "./table.js";


### PR DESCRIPTION
Supports [this fix](https://github.com/observablehq/observablehq/pull/10916), which makes schema inference consistent across stdlib and the monorepo.