### PR TITLE
duckdb-wasm@1.24 depends on arrow11

### DIFF
--- a/bin/resolve-dependencies.js
+++ b/bin/resolve-dependencies.js
@@ -68,6 +68,10 @@ const mains = ["unpkg", "jsdelivr", "browser", "main"];
     console.log(`export const arrow9 = dependency("${info.name}", "${info.version}", "+esm");`);
   }
   {
+    const info = await resolve("apache-arrow@11");
+    console.log(`export const arrow11 = dependency("${info.name}", "${info.version}", "+esm");`);
+  }
+  {
     const info = await resolve("arquero");
     console.log(`export const arquero = dependency("${info.name}", "${info.version}", "${info.export}");`);
   }

--- a/src/arrow.js
+++ b/src/arrow.js
@@ -1,4 +1,4 @@
-import {arrow9 as arrow} from "./dependencies.js";
+import {arrow11 as arrow} from "./dependencies.js";
 import {cdn} from "./require.js";
 
 // Returns true if the vaue is an Apache Arrow table. This uses a “duck” test

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -15,6 +15,7 @@ export const vegalite = dependency("vega-lite", "5.6.0", "build/vega-lite.min.js
 export const vegaliteApi = dependency("vega-lite-api", "5.0.0", "build/vega-lite-api.min.js");
 export const arrow4 = dependency("apache-arrow", "4.0.1", "Arrow.es2015.min.js");
 export const arrow9 = dependency("apache-arrow", "9.0.0", "+esm");
+export const arrow11 = dependency("apache-arrow", "11.0.0", "+esm");
 export const arquero = dependency("arquero", "4.8.8", "dist/arquero.min.js");
 export const topojson = dependency("topojson-client", "3.1.0", "dist/topojson-client.min.js");
 export const exceljs = dependency("exceljs", "4.3.0", "dist/exceljs.min.js");

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -1,5 +1,5 @@
 import {autoType, csvParse, csvParseRows, tsvParse, tsvParseRows} from "d3-dsv";
-import {arrow4, arrow9, jszip, exceljs} from "./dependencies.js";
+import {arrow4, arrow9, arrow11, jszip, exceljs} from "./dependencies.js";
 import {cdn, requireDefault} from "./require.js";
 import {SQLiteDatabaseClient} from "./sqlite.js";
 import {Workbook} from "./xlsx.js";
@@ -64,6 +64,10 @@ export class AbstractFile {
       }
       case 9: {
         const [Arrow, response] = await Promise.all([import(`${cdn}${arrow9.resolve()}`), remote_fetch(this)]);
+        return Arrow.tableFromIPC(response);
+      }
+      case 11: {
+        const [Arrow, response] = await Promise.all([import(`${cdn}${arrow11.resolve()}`), remote_fetch(this)]);
         return Arrow.tableFromIPC(response);
       }
       default: throw new Error(`unsupported arrow version: ${version}`);


### PR DESCRIPTION
duckdb-wasm@1.24 depends on arrow11 (after https://github.com/duckdb/duckdb-wasm/commit/18dd6c7096fe888dbdfb7e9a1cdd559560d53c97); because of this, with #356 loadDataSource does not create tables from arrays any more.

In this tentative PR I add full support for arrow11 on top of the existing arrow9 and arrow4. It might be enough to support arrow11 only in the case of duckdb, but supporting it as a filetype felt the right thing to do. (Not tested though.)

DEMO: https://observablehq.com/@observablehq/duckdb-1-24-breaks-insertion-in-sql-mode

Here's a unit test I wanted to add, unfortunately it fails because loadArrow() wants an http-resource.

```diff
--- a/test/query-test.js
+++ b/test/query-test.js
@@ -1,5 +1,5 @@
 import assert from "assert";
-import {__query} from "../src/table.js";
+import {__query, loadDataSource} from "../src/table.js";
 import it, {invalidator} from "./invalidation.js";

@@ -109,3 +109,12 @@ describe("__query.sql", () => {
+
+describe("loadDataSource", () => {
+  it("loads an array as a sql table", async () => {
+    const [invalidation] = invalidator();
+    const data = [{x: 1}, {x: 2}];
+    const db = await loadDataSource(data, "sql", "data");
+    assert.strictEqual(await __query.sql(db, invalidation)`SELECT * FROM data`, data); // TODO
+  });
+});
```