### PR TITLE
Add file.csv({typed: "auto"}) option that uses inferSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Returns a promise to the file’s contents, parsed as tab-separated values (TSV)
 const data = await FileAttachment("cars.tsv").tsv();
 ```
 
-If <i>array</i> is true, an array of arrays is returned; otherwise, the first row is assumed to be the header row and an array of objects is returned, and the returned array has a <i>data</i>.columns property that is an array of column names. (See <a href="https://github.com/d3/d3-dsv/blob/main/README.md#dsv_parseRows">d3.tsvParseRows</a>.) If <i>typed</i> is true, [automatic type inference](https://observablehq.com/@d3/d3-autotype) is applied; only use this feature if you know your data is compatible.
+If <i>array</i> is true, an array of arrays is returned; otherwise, the first row is assumed to be the header row and an array of objects is returned, and the returned array has a <i>data</i>.columns property that is an array of column names. (See <a href="https://github.com/d3/d3-dsv/blob/main/README.md#dsv_parseRows">d3.tsvParseRows</a>.) If <i>typed</i> is true, [automatic type inference](https://observablehq.com/@d3/d3-autotype) is applied to each row independently; if <i>typed</i> is “auto”, the type inference is based on a sample of rows. Only use this feature if you know your data is compatible.
 
 <a href="#attachment_image" name="attachment_image">#</a> *attachment*.<b>image</b>(<i>options</i>) [<>](https://github.com/observablehq/stdlib/blob/main/src/fileAttachment.js "Source")
 

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -11,7 +11,7 @@ async function remote_fetch(file) {
   return response;
 }
 
-function enforceSchema(source, schema = inferSchema(source)) {
+export function enforceSchema(source, schema = inferSchema(source)) {
   const types = new Map(schema.map(({name, type}) => [name, type]));
   return Object.assign(source.map(d => coerceRow(d, types, schema)), {schema});
 }

--- a/src/fileAttachment.js
+++ b/src/fileAttachment.js
@@ -13,16 +13,16 @@ async function remote_fetch(file) {
 
 async function dsv(file, delimiter, {array = false, typed = false} = {}) {
   const text = await file.text();
-  const parser = (delimiter === "\t"
+  const parse = (delimiter === "\t"
     ? (array ? tsvParseRows : tsvParse)
     : (array ? csvParseRows : csvParse));
   if (typed === "auto") {
-    const source = parser(text);
+    const source = parse(text);
     const schema = inferSchema(source);
     const types = new Map(schema.map(({name, type}) => [name, type]));
     return source.map(d => coerceRow(d, types, schema));
   }
-  return parser(text, typed && autoType);
+  return parse(text, typed && autoType);
 }
 
 export class AbstractFile {

--- a/src/table.js
+++ b/src/table.js
@@ -199,8 +199,8 @@ function sourceCache(loadSource) {
 const loadChartDataSource = sourceCache(async (source) => {
   if (source instanceof FileAttachment) {
     switch (source.mimeType) {
-      case "text/csv": return source.csv({typed: true});
-      case "text/tab-separated-values": return source.tsv({typed: true});
+      case "text/csv": return source.csv({typed: "auto"});
+      case "text/tab-separated-values": return source.tsv({typed: "auto"});
       case "application/json": return source.json();
     }
     throw new Error(`unsupported file type: ${source.mimeType}`);
@@ -785,7 +785,7 @@ export function __table(source, operations) {
   return source;
 }
 
-function coerceRow(object, types, schema) {
+export function coerceRow(object, types, schema) {
   const coerced = {};
   for (const col of schema) {
     const type = types.get(col.name);

--- a/src/table.js
+++ b/src/table.js
@@ -626,7 +626,7 @@ export function __table(source, operations) {
   let {schema, columns} = source;
   let inferredSchema = false;
   if (!isQueryResultSetSchema(schema)) {
-    schema = inferSchema(source, columns);
+    schema = inferSchema(source);
     inferredSchema = true;
   }
   // Combine column types from schema with user-selected types in operations

--- a/src/table.js
+++ b/src/table.js
@@ -626,7 +626,7 @@ export function __table(source, operations) {
   let {schema, columns} = source;
   let inferredSchema = false;
   if (!isQueryResultSetSchema(schema)) {
-    schema = inferSchema(source);
+    schema = inferSchema(source, isQueryResultSetColumns(columns) ? columns : undefined);
     inferredSchema = true;
   }
   // Combine column types from schema with user-selected types in operations
@@ -844,7 +844,7 @@ function getAllKeys(rows) {
   return Array.from(keys);
 }
 
-export function inferSchema(source, columns = source.columns || getAllKeys(source)) {
+export function inferSchema(source, columns = getAllKeys(source)) {
   const schema = [];
   const sampleSize = 100;
   const sample = source.slice(0, sampleSize);

--- a/src/table.js
+++ b/src/table.js
@@ -844,7 +844,7 @@ function getAllKeys(rows) {
   return Array.from(keys);
 }
 
-export function inferSchema(source, columns = getAllKeys(source)) {
+export function inferSchema(source, columns = source.columns || getAllKeys(source)) {
   const schema = [];
   const sampleSize = 100;
   const sample = source.slice(0, sampleSize);

--- a/test/fileAttachments-test.js
+++ b/test/fileAttachments-test.js
@@ -1,4 +1,5 @@
 import assert from "assert";
+import {enforceSchema} from "../src/fileAttachment.js";
 import {FileAttachments} from "../src/index.js";
 
 it("FileAttachments is exported by stdlib", () => {
@@ -37,4 +38,30 @@ it("FileAttachment works with Promises that resolve to URLs", async () => {
   const file = FileAttachment("otherfile");
   assert.strictEqual(file.constructor.name, "FileAttachment");
   assert.strictEqual(await file.url(), "https://example.com/otherfile.js");
+});
+
+it("enforceSchema coerces an array of objects", () => {
+  assert.deepStrictEqual(
+    enforceSchema([{a: "0", b: "1", c: "2"}]),
+    Object.assign(
+      [{a: 0, b: 1, c: 2}],
+      {schema: [
+        {
+          inferred: "integer",
+          name: "a",
+          type: "integer"
+        },
+        {
+          inferred: "integer",
+          name: "b",
+          type: "integer"
+        },
+        {
+          inferred: "integer",
+          name: "c",
+          type: "integer"
+        }
+      ]}
+    )
+  );
 });

--- a/test/fileAttachments-test.js
+++ b/test/fileAttachments-test.js
@@ -1,6 +1,7 @@
 import assert from "assert";
 import {enforceSchema} from "../src/fileAttachment.js";
 import {FileAttachments} from "../src/index.js";
+import {inferSchema} from "../src/table.js";
 
 it("FileAttachments is exported by stdlib", () => {
   assert.strictEqual(typeof FileAttachments, "function");
@@ -41,8 +42,9 @@ it("FileAttachment works with Promises that resolve to URLs", async () => {
 });
 
 it("enforceSchema coerces an array of objects", () => {
+  const source = [{a: "0", b: "1", c: "2"}];
   assert.deepStrictEqual(
-    enforceSchema([{a: "0", b: "1", c: "2"}]),
+    enforceSchema(source, inferSchema(source)),
     Object.assign(
       [{a: 0, b: 1, c: 2}],
       {schema: [

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1056,6 +1056,13 @@ describe("inferSchema", () => {
       [{name: "x", type: "number", inferred: "number"}]
     );
   });
+
+  it("looks at source.columns", () => {
+    assert.deepStrictEqual(
+      inferSchema(Object.assign([{a: "0", b: "1", c: "2"}], {columns: ["a", "b"]})),
+      [{name: "a", type: "integer", inferred: "integer"}, {name: "b", type: "integer", inferred: "integer"}]
+    );
+  });
 });
 
 describe("coerceToType", () => {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1056,13 +1056,6 @@ describe("inferSchema", () => {
       [{name: "x", type: "number", inferred: "number"}]
     );
   });
-
-  it("looks at source.columns", () => {
-    assert.deepStrictEqual(
-      inferSchema(Object.assign([{a: "0", b: "1", c: "2"}], {columns: ["a", "b"]})),
-      [{name: "a", type: "integer", inferred: "integer"}, {name: "b", type: "integer", inferred: "integer"}]
-    );
-  });
 });
 
 describe("coerceToType", () => {


### PR DESCRIPTION
Since 2020, file.csv and file.tsv have allowed you to pass {typed: true} to apply d3.autoType, which looks line by line and tries to guess the types. More recently, the data table cell has introduced an internal [inferSchema function](https://github.com/observablehq/stdlib/blob/89f27007453ea1919493dca3fb94b7a5bde03222/src/table.js#L835-L885), which instead looks at a sample of rows and picks the most frequent type.

This introduces a new {typed: "auto"} option, which calls inferSchema and then coerces all rows to that schema, allowing FileAttachment calls to match the behavior of the data table cell. It also uses that new "auto" option in loadChartDataSource.

This duplicates a couple lines of the __table function…

https://github.com/observablehq/stdlib/blob/89f27007453ea1919493dca3fb94b7a5bde03222/src/table.js#L621

https://github.com/observablehq/stdlib/blob/89f27007453ea1919493dca3fb94b7a5bde03222/src/table.js#L630

…but, since that has some other logic for overriding types, I didn’t bother refactoring anything for now.

Note that, since the existing code only checks for the truthiness of typed, and “auto” is truthy, this could theoretically change the behavior of existing code, if anyone has somehow already said `typed: "auto"`. But I think that’d be very rare!!