### PR TITLE
Move type inference and coercion to loadDataSource

### DIFF
--- a/test/table-test.js
+++ b/test/table-test.js
@@ -631,8 +631,9 @@ describe("__table", () => {
       {a: new Date("2021-01-02")},
       {a: new Date("2021-01-03")}
     ];
+    source.schema = [{name: "a", type: "date", inferred: "date"}];
     const expected = [{a: new Date("2021-01-02")}];
-    expected.schema = [{name: "a", type: "date", inferred: "date"}];
+    expected.schema = source.schema;
     assert.deepStrictEqual(__table(source, operationsEquals), expected);
   });
 
@@ -660,6 +661,7 @@ describe("__table", () => {
     expectedAsc.schema = source.schema;
     assert.deepStrictEqual(__table(source, operationsAsc), expectedAsc);
     const sourceExtended = [...source, {a: 1, b: 3, c: 3}, {a: 1, b: 5, c: 3}];
+    sourceExtended.schema = source.schema;
     const operationsMulti = {
       ...EMPTY_TABLE_DATA.operations,
       sort: [
@@ -685,14 +687,15 @@ describe("__table", () => {
     const sourceWithMissing = [
       {a: 1}, {a: null}, {a: undefined}, {a: 10}, {a: 5}, {a: NaN}, {a: null}, {a: 20}
     ];
+    sourceWithMissing.schema = [{name: "a", type: "number", inferred: "number"}];
     const operationsDesc = {
       ...EMPTY_TABLE_DATA.operations,
       sort: [{column: "a", direction: "desc"}]
     };
     const expectedDesc = [
-      {a: 20}, {a: 10}, {a: 5}, {a: 1}, {a: NaN}, {a: NaN}, {a: NaN}, {a: NaN}
+      {a: 20}, {a: 10}, {a: 5}, {a: 1}, {a: null}, {a: undefined}, {a: NaN}, {a: null}
     ];
-    expectedDesc.schema = [{name: "a", type: "number", inferred: "number"}];
+    expectedDesc.schema = sourceWithMissing.schema;
     assert.deepStrictEqual(
       __table(sourceWithMissing, operationsDesc),
       expectedDesc
@@ -702,9 +705,9 @@ describe("__table", () => {
       sort: [{column: "a", direction: "asc"}]
     };
     const expectedAsc = [
-      {a: 1}, {a: 5}, {a: 10}, {a: 20}, {a: NaN}, {a: NaN}, {a: NaN}, {a: NaN}
+      {a: 1}, {a: 5}, {a: 10}, {a: 20}, {a: null}, {a: undefined}, {a: NaN}, {a: null}
     ];
-    expectedAsc.schema = [{name: "a", type: "number", inferred: "number"}];
+    expectedAsc.schema = sourceWithMissing.schema;
     assert.deepStrictEqual(
       __table(sourceWithMissing, operationsAsc),
       expectedAsc


### PR DESCRIPTION
Supports https://github.com/observablehq/observablehq/pull/11480.

This PR moves the type inference and coercion step from `__table` into `loadDataSource`, in order to make the inferred schema available to the worker and unify our two code paths for type inference (see the description in the accompanying [Next PR](https://github.com/observablehq/observablehq/pull/11480) for more details).

This is a bit of a tentative PR because I'm worried that there are some with inferring and coercing in `loadDataSource` that I haven't thought of. One that I can clearly see is that we'll end up coercing data when we don't need to – for instance, when the worker attempts to fetch a table schema, it only needs the inferred schema and doesn't need all the rows in the data source to be coerced as well.