### PR TITLE
Add and export getSchema function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,5 +10,6 @@ export {
   isDatabaseClient,
   __table as applyDataTableOperations,
   getTypeValidator,
-  inferSchema
+  inferSchema,
+  getSchema
 } from "./table.js";

--- a/src/table.js
+++ b/src/table.js
@@ -636,8 +636,8 @@ export function __table(source, operations) {
   const schemaInfo = getSchema(source);
   let {columns} = source;
   let {schema, shouldCoerce} = schemaInfo;
-  const types = new Map(schema.map(({name, type}) => [name, type]));
   // Combine column types from schema with user-selected types in operations
+  const types = new Map(schema.map(({name, type}) => [name, type]));
   if (operations.types) {
     for (const {name, type} of operations.types) {
       types.set(name, type);

--- a/src/table.js
+++ b/src/table.js
@@ -633,9 +633,8 @@ export function getSchema(source) {
 // function to do table operations on in-memory data?
 export function __table(source, operations) {
   const input = source;
-  const schemaInfo = getSchema(source);
   let {columns} = source;
-  let {schema, inferred} = schemaInfo;
+  let {schema, inferred} = getSchema(source);
   // Combine column types from schema with user-selected types in operations
   const types = new Map(schema.map(({name, type}) => [name, type]));
   if (operations.types) {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1244,33 +1244,20 @@ describe("getSchema", () => {
 
   beforeEach(() => {
     source = [
-      {a: 1, b: 2, c: 3},
-      {a: 2, b: 4, c: 6},
-      {a: 3, b: 6, c: 9}
+      {a: 1, b: "foo"},
+      {a: 2, b: "bar"}
     ];
     source.schema = [
       {name: "a", type: "integer", inferred: "integer"},
-      {name: "b", type: "integer", inferred: "integer"},
-      {name: "c", type: "integer", inferred: "integer"}
+      {name: "b", type: "string", inferred: "string"}
     ];
   });
 
 
-  it("respects schema from source if one exists and there are no type assertions", () => {
+  it("respects schema from source, if one exists", () => {
     const {schema, shouldCoerce} = getSchema(source);
     assert.strictEqual(shouldCoerce, false);
     assert.strictEqual(schema, source.schema);
-  });
-
-  it("respects type assertions", () => {
-    const types = [{name: "a", type: "string"}];
-    const {schema, shouldCoerce} = getSchema(source, types);
-    assert.strictEqual(shouldCoerce, true);
-    assert.deepStrictEqual(schema, [
-      {name: "a", type: "string", inferred: "integer"},
-      {name: "b", type: "integer", inferred: "integer"},
-      {name: "c", type: "integer", inferred: "integer"}
-    ]);
   });
 
   it("infers schema if source has no schema", () => {
@@ -1279,8 +1266,7 @@ describe("getSchema", () => {
     assert.strictEqual(shouldCoerce, true);
     assert.deepStrictEqual(schema,[
       {name: "a", type: "integer", inferred: "integer"},
-      {name: "b", type: "integer", inferred: "integer"},
-      {name: "c", type: "integer", inferred: "integer"}
+      {name: "b", type: "string", inferred: "string"}
     ]);
   });
 
@@ -1290,8 +1276,7 @@ describe("getSchema", () => {
     assert.strictEqual(shouldCoerce, true);
     assert.deepStrictEqual(schema,[
       {name: "a", type: "integer", inferred: "integer"},
-      {name: "b", type: "integer", inferred: "integer"},
-      {name: "c", type: "integer", inferred: "integer"}
+      {name: "b", type: "string", inferred: "string"}
     ]);
   });
 });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -1255,15 +1255,15 @@ describe("getSchema", () => {
 
 
   it("respects schema from source, if one exists", () => {
-    const {schema, shouldCoerce} = getSchema(source);
-    assert.strictEqual(shouldCoerce, false);
+    const {schema, inferred} = getSchema(source);
+    assert.strictEqual(inferred, false);
     assert.strictEqual(schema, source.schema);
   });
 
   it("infers schema if source has no schema", () => {
     source.schema = undefined;
-    const {schema, shouldCoerce} = getSchema(source);
-    assert.strictEqual(shouldCoerce, true);
+    const {schema, inferred} = getSchema(source);
+    assert.strictEqual(inferred, true);
     assert.deepStrictEqual(schema,[
       {name: "a", type: "integer", inferred: "integer"},
       {name: "b", type: "string", inferred: "string"}
@@ -1272,8 +1272,8 @@ describe("getSchema", () => {
 
   it("infers schema if schema is invalid", () => {
     source.schema = ["number"];
-    const {schema, shouldCoerce} = getSchema(source);
-    assert.strictEqual(shouldCoerce, true);
+    const {schema, inferred} = getSchema(source);
+    assert.strictEqual(inferred, true);
     assert.deepStrictEqual(schema,[
       {name: "a", type: "integer", inferred: "integer"},
       {name: "b", type: "string", inferred: "string"}

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -3,7 +3,8 @@ import {
   getTypeValidator,
   inferSchema,
   makeQueryTemplate,
-  __table
+  __table,
+  getSchema
 } from "../src/table.js";
 import assert from "assert";
 
@@ -805,13 +806,37 @@ describe("__table", () => {
       "b",
       "c"
     ]);
-    source.schema = [
-      {name: "a", type: "integer", inferred: "integer"},
+    assert.deepStrictEqual(__table(source, operations).schema, [
+      {name: "nameA", type: "integer", inferred: "integer"},
+      {name: "b", type: "integer", inferred: "integer"},
+      {name: "c", type: "integer", inferred: "integer"}
+    ]);
+  });
+
+  it("__table type assertions", () => {
+    const operations = {
+      ...EMPTY_TABLE_DATA.operations,
+      types: [{name: "a", type: "string"}]
+    };
+    const expected = [
+      {a: "1", b: 2, c: 3},
+      {a: "2", b: 4, c: 6},
+      {a: "3", b: 6, c: 9}
+    ];
+    expected.schema = [
+      {name: "a", type: "string", inferred: "integer"},
       {name: "b", type: "integer", inferred: "integer"},
       {name: "c", type: "integer", inferred: "integer"}
     ];
+    assert.deepStrictEqual(__table(source, operations), expected);
+    source.columns = ["a", "b", "c"];
+    assert.deepStrictEqual(__table(source, operations).columns, [
+      "a",
+      "b",
+      "c"
+    ]);
     assert.deepStrictEqual(__table(source, operations).schema, [
-      {name: "nameA", type: "integer", inferred: "integer"},
+      {name: "a", type: "string", inferred: "integer"},
       {name: "b", type: "integer", inferred: "integer"},
       {name: "c", type: "integer", inferred: "integer"}
     ]);
@@ -1212,4 +1237,61 @@ describe("coerceToType", () => {
 
   // Note: if type is "raw", coerceToType() will not be called. Instead, values
   // will be returned from coerceRow().
+});
+
+describe("getSchema", () => {
+  let source;
+
+  beforeEach(() => {
+    source = [
+      {a: 1, b: 2, c: 3},
+      {a: 2, b: 4, c: 6},
+      {a: 3, b: 6, c: 9}
+    ];
+    source.schema = [
+      {name: "a", type: "integer", inferred: "integer"},
+      {name: "b", type: "integer", inferred: "integer"},
+      {name: "c", type: "integer", inferred: "integer"}
+    ];
+  });
+
+
+  it("respects schema from source if one exists and there are no type assertions", () => {
+    const {schema, shouldCoerce} = getSchema(source);
+    assert.strictEqual(shouldCoerce, false);
+    assert.strictEqual(schema, source.schema);
+  });
+
+  it("respects type assertions", () => {
+    const types = [{name: "a", type: "string"}];
+    const {schema, shouldCoerce} = getSchema(source, types);
+    assert.strictEqual(shouldCoerce, true);
+    assert.deepStrictEqual(schema, [
+      {name: "a", type: "string", inferred: "integer"},
+      {name: "b", type: "integer", inferred: "integer"},
+      {name: "c", type: "integer", inferred: "integer"}
+    ]);
+  });
+
+  it("infers schema if source has no schema", () => {
+    source.schema = undefined;
+    const {schema, shouldCoerce} = getSchema(source);
+    assert.strictEqual(shouldCoerce, true);
+    assert.deepStrictEqual(schema,[
+      {name: "a", type: "integer", inferred: "integer"},
+      {name: "b", type: "integer", inferred: "integer"},
+      {name: "c", type: "integer", inferred: "integer"}
+    ]);
+  });
+
+  it("infers schema if schema is invalid", () => {
+    source.schema = ["number"];
+    const {schema, shouldCoerce} = getSchema(source);
+    assert.strictEqual(shouldCoerce, true);
+    assert.deepStrictEqual(schema,[
+      {name: "a", type: "integer", inferred: "integer"},
+      {name: "b", type: "integer", inferred: "integer"},
+      {name: "c", type: "integer", inferred: "integer"}
+    ]);
+  });
 });


### PR DESCRIPTION
This PR adds a `getSchema` function, building on a [suggestion from Mike](https://github.com/observablehq/observablehq/pull/11496#discussion_r1165998001). This function conditionally infers a schema depending on whether or not a valid one exists on the source, combines the schema with any saved type assertions, and determines whether or not the source data needs to be coerced.

We will use `getSchema` in both `__table` and in the table schema tasks in the worker (I'll update https://github.com/observablehq/observablehq/pull/11496 to use this function), and thereby unify the two paths that we currently have for type inference.

I also added a missing unit test for type assertion in `__table`, as well as some tests for `getSchema`.