### PR TITLE
Remove .columns

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -633,7 +633,6 @@ export function getSchema(source) {
 // function to do table operations on in-memory data?
 export function __table(source, operations) {
   const input = source;
-  let {columns} = source;
   let {schema, inferred} = getSchema(source);
   // Combine column types from schema with user-selected types in operations
   const types = new Map(schema.map(({name, type}) => [name, type]));
@@ -756,9 +755,6 @@ export function __table(source, operations) {
       const schemaByName = new Map(schema.map((s) => [s.name, s]));
       schema = operations.select.columns.map((c) => schemaByName.get(c));
     }
-    if (columns) {
-      columns = operations.select.columns;
-    }
     source = source.map((d) =>
       Object.fromEntries(operations.select.columns.map((c) => [c, d[c]]))
     );
@@ -771,12 +767,6 @@ export function __table(source, operations) {
         return ({...s, ...(override ? {name: override.name} : null)});
       });
     }
-    if (columns) {
-      columns = columns.map((c) => {
-        const override = overridesByName.get(c);
-        return override?.name ?? c;
-      });
-    }
     source = source.map((d) =>
       Object.fromEntries(Object.keys(d).map((k) => {
         const override = overridesByName.get(k);
@@ -786,7 +776,6 @@ export function __table(source, operations) {
   }
   if (source !== input) {
     if (schema) source.schema = schema;
-    if (columns) source.columns = columns;
   }
   return source;
 }

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -801,11 +801,6 @@ describe("__table", () => {
     ];
     assert.deepStrictEqual(__table(source, operations), expected);
     source.columns = ["a", "b", "c"];
-    assert.deepStrictEqual(__table(source, operations).columns, [
-      "nameA",
-      "b",
-      "c"
-    ]);
     assert.deepStrictEqual(__table(source, operations).schema, [
       {name: "nameA", type: "integer", inferred: "integer"},
       {name: "b", type: "integer", inferred: "integer"},
@@ -830,11 +825,6 @@ describe("__table", () => {
     ];
     assert.deepStrictEqual(__table(source, operations), expected);
     source.columns = ["a", "b", "c"];
-    assert.deepStrictEqual(__table(source, operations).columns, [
-      "a",
-      "b",
-      "c"
-    ]);
     assert.deepStrictEqual(__table(source, operations).schema, [
       {name: "a", type: "string", inferred: "integer"},
       {name: "b", type: "integer", inferred: "integer"},


### PR DESCRIPTION
(Based on a suggestion [from Mike](https://github.com/observablehq/stdlib/pull/363#discussion_r1167258471))

Remove .columns from `__table`. It's no longer needed since we always guarantee that we'll return a .schema, and .schema is a superset of the information in .columns.

One thing I'm not too sure about – if the source has a .columns property and the source isn't modified in `__table`, the .columns property will pass through and remain in the output. Is that ok, or do we need to standardize `__table` by making sure .schema is the only property on the output?