### PR TITLE
Derived columns

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -662,6 +662,7 @@ export function __table(source, operations) {
   if (!isQueryResultSetSchema(schema)) {
     schema = inferSchema(source, columns);
   }
+  const fullSchema = schema.slice();
   // if(!typesApplied) source = applyTypes(source, operations);
   source = applyTypes(source, operations);
   for (const {type, operands} of operations.filter) {
@@ -802,6 +803,7 @@ export function __table(source, operations) {
     if (schema) source.schema = schema;
     if (columns) source.columns = columns;
   }
+  source.fullSchema = fullSchema;
   return source;
 }
 

--- a/src/table.js
+++ b/src/table.js
@@ -155,12 +155,12 @@ export const __query = Object.assign(
     source = await loadTableDataSource(await source, name);
     if (isDatabaseClient(source)) return evaluateQuery(source, makeQueryTemplate(operations, source), invalidation);
     if (isDataArray(source)) {
-      source = __table(source, operations);
       if(operations.derive) {
         operations.derive.map(({name, value}) => {
           source = source.map((row, index, rows) => ({...row, [name]: value(row, index, rows)}));
         });
       }
+      source = __table(source, operations);
       return source;
     }
     if (!source) throw new Error("missing data source");

--- a/src/table.js
+++ b/src/table.js
@@ -154,7 +154,15 @@ export const __query = Object.assign(
   async (source, operations, invalidation, name) => {
     source = await loadTableDataSource(await source, name);
     if (isDatabaseClient(source)) return evaluateQuery(source, makeQueryTemplate(operations, source), invalidation);
-    if (isDataArray(source)) return __table(source, operations);
+    if (isDataArray(source)) {
+      source = __table(source, operations);
+      if(operations.derive) {
+        operations.derive.map(({name, value}) => {
+          source = source.map((row, index, rows) => ({...row, [name]: value(row, index, rows)}));
+        });
+      }
+      return source;
+    }
     if (!source) throw new Error("missing data source");
     throw new Error("invalid data source");
   },

--- a/src/table.js
+++ b/src/table.js
@@ -681,8 +681,8 @@ export function __table(source, operations) {
         }
       });
     });
-    // We perform an additional round of type inference and coercion on derived
-    // columns here.
+    // Since derived columns are untyped by default, we do a pass of type
+    // inference and coercion after computing the derived values.
     const typedDerived = applyTypes(derivedSource, operations);
     // Merge derived source and schema with the larger dataset.
     source = source.map((row, i) => ({...row, ...typedDerived.source[i]}));

--- a/src/table.js
+++ b/src/table.js
@@ -680,7 +680,7 @@ export function __table(source, operations) {
     // step.
     const derivedSource = [];
     operations.derive.map(({name, value}) => {
-      let columnErrors = new Map();
+      let columnErrors = [];
       // Derived column formulas may reference renamed columns, so we must
       // compute derivations on the renamed source. However, we don't modify the
       // source itself with renamed names until after the other operations are
@@ -692,7 +692,7 @@ export function __table(source, operations) {
         try {
           resolved = value(row, index, rows);
         } catch (error) {
-          columnErrors.set(index, error);
+          columnErrors.push({index, error});
           resolved = undefined;
         }
         if (derivedSource[index]) {
@@ -701,7 +701,7 @@ export function __table(source, operations) {
           derivedSource.push({[name]: resolved});
         }
       });
-      errors.set(name, columnErrors);
+      if (columnErrors.length) errors.set(name, columnErrors);
     });
     // Since derived columns are untyped by default, we do a pass of type
     // inference and coercion after computing the derived values.

--- a/src/table.js
+++ b/src/table.js
@@ -662,7 +662,6 @@ export function __table(source, operations) {
   const typed = applyTypes(source, operations);
   source = typed.source;
   let schema = typed.schema;
-  // TODO_ANNIE add tests for __table derive
   if (operations.derive) {
     // Derived columns may depend on coerced values from the original data source,
     // so we must evaluate derivations after the initial inference and coercion
@@ -788,7 +787,7 @@ export function __table(source, operations) {
   if (operations.select.columns) {
     if (schema) {
       const columnsSet = new Set(operations.select.columns);
-      schema = schema.map((s) => ({...s, hidden: !columnsSet.has(s.name)}));
+      schema = schema.map((s) => ({...s, ...(!columnsSet.has(s.name) ? {hidden: true} : null)}));
     }
     if (columns) {
       columns = operations.select.columns;

--- a/src/table.js
+++ b/src/table.js
@@ -666,9 +666,13 @@ export function __table(source, operations) {
     // Derived columns may depend on coerced values from the original data source,
     // so we must evaluate derivations after the initial inference and coercion
     // step.
-    let derivedSource = [];
+    let derivedSource = source.slice();
     operations.derive.map(({name, value}) => {
-      source.map((row, index, rows) => {
+      // TODO Allow derived columns to reference one another, regardless of the
+      // order in which they are created. In the current implementation, a
+      // derived column can only reference derived columns that come before it
+      // in operations.derive.
+      derivedSource.map((row, index, rows) => {
         let resolved = value(row, index, rows);
         if (derivedSource[index]) {
           derivedSource[index] = {...derivedSource[index], [name]: resolved};

--- a/src/table.js
+++ b/src/table.js
@@ -685,7 +685,6 @@ export function __table(source, operations) {
     source = source.map((row, i) => ({...row, ...typedDerived.source[i]}));
     schema = [...schema, ...typedDerived.schema];
   }
-  const fullSchema = schema.slice();
   for (const {type, operands} of operations.filter) {
     const [{value: column}] = operands;
     const values = operands.slice(1).map(({value}) => value);
@@ -788,8 +787,8 @@ export function __table(source, operations) {
   }
   if (operations.select.columns) {
     if (schema) {
-      const schemaByName = new Map(schema.map((s) => [s.name, s]));
-      schema = operations.select.columns.map((c) => schemaByName.get(c));
+      const columnsSet = new Set(operations.select.columns);
+      schema = schema.map((s) => ({...s, hidden: !columnsSet.has(s.name)}));
     }
     if (columns) {
       columns = operations.select.columns;
@@ -823,7 +822,6 @@ export function __table(source, operations) {
     if (schema) source.schema = schema;
     if (columns) source.columns = columns;
   }
-  source.fullSchema = fullSchema;
   return source;
 }
 

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -505,6 +505,7 @@ describe("__table", () => {
     const expectedEmpty = [{}, {}, {}];
     expectedEmpty.schema = [];
     expectedEmpty.fullSchema = source.schema;
+    expectedEmpty.errors = new Map();
     assert.deepStrictEqual(
       __table(source, operationsEmptyColumns),
       expectedEmpty
@@ -516,6 +517,7 @@ describe("__table", () => {
     const expectedSelected = [{a: 1}, {a: 2}, {a: 3}];
     expectedSelected.schema = [{name: "a", type: "integer", inferred: "integer"}];
     expectedSelected.fullSchema = source.schema;
+    expectedSelected.errors = new Map();
     assert.deepStrictEqual(
       __table(source, operationsSelectedColumns),
       expectedSelected
@@ -549,6 +551,7 @@ describe("__table", () => {
     const expectedEq = [{a: 1, b: 2, c: 3}];
     expectedEq.schema = source.schema;
     expectedEq.fullSchema = source.schema;
+    expectedEq.errors = new Map();
     assert.deepStrictEqual(__table(source, operationsEquals), expectedEq);
     const operationsComparison = {
       ...EMPTY_TABLE_DATA.operations,
@@ -572,6 +575,7 @@ describe("__table", () => {
     const expectedLtGt = [{a: 2, b: 4, c: 6}];
     expectedLtGt.schema = source.schema;
     expectedLtGt.fullSchema = source.schema;
+    expectedLtGt.errors = new Map();
     assert.deepStrictEqual(__table(source, operationsComparison), expectedLtGt);
   });
 
@@ -591,6 +595,7 @@ describe("__table", () => {
     const expectedEq = [{a: 1, b: 2, c: 3}];
     expectedEq.schema = source.schema;
     expectedEq.fullSchema = source.schema;
+    expectedEq.errors = new Map();
     assert.deepStrictEqual(__table(source, operationsEquals), expectedEq);
     const operationsComparison = {
       ...EMPTY_TABLE_DATA.operations,
@@ -614,6 +619,7 @@ describe("__table", () => {
     const expectedLteGte = [{a: 2, b: 4, c: 6}];
     expectedLteGte.schema = source.schema;
     expectedLteGte.fullSchema = source.schema;
+    expectedLteGte.errors = new Map();
     assert.deepStrictEqual(
       __table(source, operationsComparison),
       expectedLteGte
@@ -641,6 +647,7 @@ describe("__table", () => {
     const expected = [{a: new Date("2021-01-02")}];
     expected.schema = [{name: "a", type: "date", inferred: "date"}];
     expected.fullSchema = expected.schema;
+    expected.errors = new Map();
     assert.deepStrictEqual(__table(source, operationsEquals), expected);
   });
 
@@ -656,6 +663,7 @@ describe("__table", () => {
     ];
     expectedDesc.schema = source.schema;
     expectedDesc.fullSchema = source.schema;
+    expectedDesc.errors = new Map();
     assert.deepStrictEqual(__table(source, operationsDesc), expectedDesc);
     const operationsAsc = {
       ...EMPTY_TABLE_DATA.operations,
@@ -668,6 +676,7 @@ describe("__table", () => {
     ];
     expectedAsc.schema = source.schema;
     expectedAsc.fullSchema = source.schema;
+    expectedAsc.errors = new Map();
     assert.deepStrictEqual(__table(source, operationsAsc), expectedAsc);
     const sourceExtended = [...source, {a: 1, b: 3, c: 3}, {a: 1, b: 5, c: 3}];
     const operationsMulti = {
@@ -686,6 +695,7 @@ describe("__table", () => {
     ];
     expectedExtended.schema = source.schema;
     expectedExtended.fullSchema = source.schema;
+    expectedExtended.errors = new Map();
     assert.deepStrictEqual(
       __table(sourceExtended, operationsMulti),
       expectedExtended
@@ -705,6 +715,7 @@ describe("__table", () => {
     ];
     expectedDesc.schema = [{name: "a", type: "number", inferred: "number"}];
     expectedDesc.fullSchema = expectedDesc.schema;
+    expectedDesc.errors = new Map();
     assert.deepStrictEqual(
       __table(sourceWithMissing, operationsDesc),
       expectedDesc
@@ -718,6 +729,7 @@ describe("__table", () => {
     ];
     expectedAsc.schema = [{name: "a", type: "number", inferred: "number"}];
     expectedAsc.fullSchema = expectedAsc.schema;
+    expectedAsc.errors = new Map();
     assert.deepStrictEqual(
       __table(sourceWithMissing, operationsAsc),
       expectedAsc
@@ -736,6 +748,7 @@ describe("__table", () => {
     ];
     sorted.schema = source.schema;
     sorted.fullSchema = source.schema;
+    sorted.errors = new Map();
     assert.deepStrictEqual(__table(source, operations), sorted);
     const originalOrder = [
       {a: 1, b: 2, c: 3},
@@ -757,6 +770,7 @@ describe("__table", () => {
     ];
     expectedToNull.schema = source.schema;
     expectedToNull.fullSchema = source.schema;
+    expectedToNull.errors = new Map();
     assert.deepStrictEqual(__table(source, operationsToNull), expectedToNull);
     const operationsFromNull = {
       ...EMPTY_TABLE_DATA.operations,
@@ -765,6 +779,7 @@ describe("__table", () => {
     const expectedFromNull = [{a: 1, b: 2, c: 3}];
     expectedFromNull.schema = source.schema;
     expectedFromNull.fullSchema = source.schema;
+    expectedFromNull.errors = new Map();
     assert.deepStrictEqual(
       __table(source, operationsFromNull),
       expectedFromNull
@@ -776,6 +791,7 @@ describe("__table", () => {
     const expectedSlice = [{a: 2, b: 4, c: 6}];
     expectedSlice.schema = source.schema;
     expectedSlice.fullSchema = source.schema;
+    expectedSlice.errors = new Map();
     assert.deepStrictEqual(__table(source, operations), expectedSlice);
   });
 
@@ -817,6 +833,7 @@ describe("__table", () => {
     ];
     expected.schema = schema;
     expected.fullSchema = schema;
+    expected.errors = new Map();
     assert.deepStrictEqual(__table(source, operations), expected);
     source.columns = ["a", "b", "c"];
     assert.deepStrictEqual(__table(source, operations).columns, [
@@ -842,6 +859,7 @@ describe("__table", () => {
       {name: "c", type: "integer", inferred: "integer"}
     ];
     expected.fullSchema = expected.schema;
+    expected.errors = new Map();
     assert.deepStrictEqual(__table(source, operations), expected);
     source.columns = ["a", "b", "c"];
     assert.deepStrictEqual(__table(source, operations).columns, [
@@ -868,6 +886,35 @@ describe("__table", () => {
       {name: "d", type: "integer", inferred: "integer"}
     ];
     expected.fullSchema = expected.schema;
+    expected.errors = new Map();
+    assert.deepStrictEqual(__table(source, operations), expected);
+  });
+
+  it("__table derived columns with errors", () => {
+    const functionWithError = (row) => row.a.b.c;
+    const operations = {
+      ...EMPTY_TABLE_DATA.operations,
+      derive: [{name: "d", value: functionWithError}]
+    };
+    let error;
+    try {
+      functionWithError(source[0]);
+    } catch (e) {
+      error = e;
+    }
+    const expected = [
+      {a: 1, b: 2, c: 3, d: undefined},
+      {a: 2, b: 4, c: 6, d: undefined},
+      {a: 3, b: 6, c: 9, d: undefined}
+    ];
+    expected.schema = [
+      {name: "a", type: "integer", inferred: "integer"},
+      {name: "b", type: "integer", inferred: "integer"},
+      {name: "c", type: "integer", inferred: "integer"},
+      {name: "d", type: "other", inferred: "other"}
+    ];
+    expected.fullSchema = expected.schema;
+    expected.errors = new Map([["d", [{index: 0, error}, {index: 1, error}, {index: 2, error}]]]);
     assert.deepStrictEqual(__table(source, operations), expected);
   });
 });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -503,7 +503,7 @@ describe("__table", () => {
       select: {columns: []}
     };
     const expectedEmpty = [{}, {}, {}];
-    expectedEmpty.schema = [];
+    expectedEmpty.schema = source.schema.map((s) => ({...s, hidden: true}));
     assert.deepStrictEqual(
       __table(source, operationsEmptyColumns),
       expectedEmpty
@@ -513,7 +513,11 @@ describe("__table", () => {
       select: {columns: ["a"]}
     };
     const expectedSelected = [{a: 1}, {a: 2}, {a: 3}];
-    expectedSelected.schema = [{name: "a", type: "integer", inferred: "integer"}];
+    expectedSelected.schema = [
+      {name: "a", type: "integer", inferred: "integer"},
+      {name: "b", type: "integer", inferred: "integer", hidden: true},
+      {name: "c", type: "integer", inferred: "integer", hidden: true}
+    ];
     assert.deepStrictEqual(
       __table(source, operationsSelectedColumns),
       expectedSelected
@@ -806,11 +810,6 @@ describe("__table", () => {
       "b",
       "c"
     ]);
-    assert.deepStrictEqual(__table(source, operations).schema, [
-      {name: "nameA", type: "integer", inferred: "integer"},
-      {name: "b", type: "integer", inferred: "integer"},
-      {name: "c", type: "integer", inferred: "integer"}
-    ]);
   });
 
   it("__table type assertions", () => {
@@ -835,11 +834,25 @@ describe("__table", () => {
       "b",
       "c"
     ]);
-    assert.deepStrictEqual(__table(source, operations).schema, [
-      {name: "a", type: "string", inferred: "integer"},
+  });
+
+  it("__table derived columns", () => {
+    const operations = {
+      ...EMPTY_TABLE_DATA.operations,
+      derive: [{name: "d", value: (row) => row.a ** 2}]
+    };
+    const expected = [
+      {a: 1, b: 2, c: 3, d: 1},
+      {a: 2, b: 4, c: 6, d: 4},
+      {a: 3, b: 6, c: 9, d: 9}
+    ];
+    expected.schema = [
+      {name: "a", type: "integer", inferred: "integer"},
       {name: "b", type: "integer", inferred: "integer"},
-      {name: "c", type: "integer", inferred: "integer"}
-    ]);
+      {name: "c", type: "integer", inferred: "integer"},
+      {name: "d", type: "integer", inferred: "integer"}
+    ];
+    assert.deepStrictEqual(__table(source, operations), expected);
   });
 });
 

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -504,6 +504,7 @@ describe("__table", () => {
     };
     const expectedEmpty = [{}, {}, {}];
     expectedEmpty.schema = [];
+    expectedEmpty.fullSchema = source.schema;
     assert.deepStrictEqual(
       __table(source, operationsEmptyColumns),
       expectedEmpty
@@ -513,11 +514,8 @@ describe("__table", () => {
       select: {columns: ["a"]}
     };
     const expectedSelected = [{a: 1}, {a: 2}, {a: 3}];
-    expectedSelected.schema = [
-      {name: "a", type: "integer", inferred: "integer"},
-      {name: "b", type: "integer", inferred: "integer"},
-      {name: "c", type: "integer", inferred: "integer"}
-    ];
+    expectedSelected.schema = [{name: "a", type: "integer", inferred: "integer"}];
+    expectedSelected.fullSchema = source.schema;
     assert.deepStrictEqual(
       __table(source, operationsSelectedColumns),
       expectedSelected
@@ -550,6 +548,7 @@ describe("__table", () => {
     };
     const expectedEq = [{a: 1, b: 2, c: 3}];
     expectedEq.schema = source.schema;
+    expectedEq.fullSchema = source.schema;
     assert.deepStrictEqual(__table(source, operationsEquals), expectedEq);
     const operationsComparison = {
       ...EMPTY_TABLE_DATA.operations,
@@ -572,6 +571,7 @@ describe("__table", () => {
     };
     const expectedLtGt = [{a: 2, b: 4, c: 6}];
     expectedLtGt.schema = source.schema;
+    expectedLtGt.fullSchema = source.schema;
     assert.deepStrictEqual(__table(source, operationsComparison), expectedLtGt);
   });
 
@@ -590,6 +590,7 @@ describe("__table", () => {
     };
     const expectedEq = [{a: 1, b: 2, c: 3}];
     expectedEq.schema = source.schema;
+    expectedEq.fullSchema = source.schema;
     assert.deepStrictEqual(__table(source, operationsEquals), expectedEq);
     const operationsComparison = {
       ...EMPTY_TABLE_DATA.operations,
@@ -612,6 +613,7 @@ describe("__table", () => {
     };
     const expectedLteGte = [{a: 2, b: 4, c: 6}];
     expectedLteGte.schema = source.schema;
+    expectedLteGte.fullSchema = source.schema;
     assert.deepStrictEqual(
       __table(source, operationsComparison),
       expectedLteGte
@@ -638,6 +640,7 @@ describe("__table", () => {
     ];
     const expected = [{a: new Date("2021-01-02")}];
     expected.schema = [{name: "a", type: "date", inferred: "date"}];
+    expected.fullSchema = expected.schema;
     assert.deepStrictEqual(__table(source, operationsEquals), expected);
   });
 
@@ -652,6 +655,7 @@ describe("__table", () => {
       {a: 1, b: 2, c: 3}
     ];
     expectedDesc.schema = source.schema;
+    expectedDesc.fullSchema = source.schema;
     assert.deepStrictEqual(__table(source, operationsDesc), expectedDesc);
     const operationsAsc = {
       ...EMPTY_TABLE_DATA.operations,
@@ -663,6 +667,7 @@ describe("__table", () => {
       {a: 3, b: 6, c: 9}
     ];
     expectedAsc.schema = source.schema;
+    expectedAsc.fullSchema = source.schema;
     assert.deepStrictEqual(__table(source, operationsAsc), expectedAsc);
     const sourceExtended = [...source, {a: 1, b: 3, c: 3}, {a: 1, b: 5, c: 3}];
     const operationsMulti = {
@@ -680,6 +685,7 @@ describe("__table", () => {
       {a: 1, b: 2, c: 3}
     ];
     expectedExtended.schema = source.schema;
+    expectedExtended.fullSchema = source.schema;
     assert.deepStrictEqual(
       __table(sourceExtended, operationsMulti),
       expectedExtended
@@ -698,6 +704,7 @@ describe("__table", () => {
       {a: 20}, {a: 10}, {a: 5}, {a: 1}, {a: NaN}, {a: NaN}, {a: NaN}, {a: NaN}
     ];
     expectedDesc.schema = [{name: "a", type: "number", inferred: "number"}];
+    expectedDesc.fullSchema = expectedDesc.schema;
     assert.deepStrictEqual(
       __table(sourceWithMissing, operationsDesc),
       expectedDesc
@@ -710,6 +717,7 @@ describe("__table", () => {
       {a: 1}, {a: 5}, {a: 10}, {a: 20}, {a: NaN}, {a: NaN}, {a: NaN}, {a: NaN}
     ];
     expectedAsc.schema = [{name: "a", type: "number", inferred: "number"}];
+    expectedAsc.fullSchema = expectedAsc.schema;
     assert.deepStrictEqual(
       __table(sourceWithMissing, operationsAsc),
       expectedAsc
@@ -727,6 +735,7 @@ describe("__table", () => {
       {a: 1, b: 2, c: 3}
     ];
     sorted.schema = source.schema;
+    sorted.fullSchema = source.schema;
     assert.deepStrictEqual(__table(source, operations), sorted);
     const originalOrder = [
       {a: 1, b: 2, c: 3},
@@ -747,6 +756,7 @@ describe("__table", () => {
       {a: 3, b: 6, c: 9}
     ];
     expectedToNull.schema = source.schema;
+    expectedToNull.fullSchema = source.schema;
     assert.deepStrictEqual(__table(source, operationsToNull), expectedToNull);
     const operationsFromNull = {
       ...EMPTY_TABLE_DATA.operations,
@@ -754,6 +764,7 @@ describe("__table", () => {
     };
     const expectedFromNull = [{a: 1, b: 2, c: 3}];
     expectedFromNull.schema = source.schema;
+    expectedFromNull.fullSchema = source.schema;
     assert.deepStrictEqual(
       __table(source, operationsFromNull),
       expectedFromNull
@@ -764,6 +775,7 @@ describe("__table", () => {
     };
     const expectedSlice = [{a: 2, b: 4, c: 6}];
     expectedSlice.schema = source.schema;
+    expectedSlice.fullSchema = source.schema;
     assert.deepStrictEqual(__table(source, operations), expectedSlice);
   });
 
@@ -798,11 +810,13 @@ describe("__table", () => {
       {nameA: 2, b: 4, c: 6},
       {nameA: 3, b: 6, c: 9}
     ];
-    expected.schema = [
+    const schema = [
       {name: "nameA", type: "integer", inferred: "integer"},
       {name: "b", type: "integer", inferred: "integer"},
       {name: "c", type: "integer", inferred: "integer"}
     ];
+    expected.schema = schema;
+    expected.fullSchema = schema;
     assert.deepStrictEqual(__table(source, operations), expected);
     source.columns = ["a", "b", "c"];
     assert.deepStrictEqual(__table(source, operations).columns, [
@@ -827,6 +841,7 @@ describe("__table", () => {
       {name: "b", type: "integer", inferred: "integer"},
       {name: "c", type: "integer", inferred: "integer"}
     ];
+    expected.fullSchema = expected.schema;
     assert.deepStrictEqual(__table(source, operations), expected);
     source.columns = ["a", "b", "c"];
     assert.deepStrictEqual(__table(source, operations).columns, [
@@ -852,6 +867,7 @@ describe("__table", () => {
       {name: "c", type: "integer", inferred: "integer"},
       {name: "d", type: "integer", inferred: "integer"}
     ];
+    expected.fullSchema = expected.schema;
     assert.deepStrictEqual(__table(source, operations), expected);
   });
 });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -503,7 +503,7 @@ describe("__table", () => {
       select: {columns: []}
     };
     const expectedEmpty = [{}, {}, {}];
-    expectedEmpty.schema = source.schema.map((s) => ({...s, hidden: true}));
+    expectedEmpty.schema = [];
     assert.deepStrictEqual(
       __table(source, operationsEmptyColumns),
       expectedEmpty
@@ -515,8 +515,8 @@ describe("__table", () => {
     const expectedSelected = [{a: 1}, {a: 2}, {a: 3}];
     expectedSelected.schema = [
       {name: "a", type: "integer", inferred: "integer"},
-      {name: "b", type: "integer", inferred: "integer", hidden: true},
-      {name: "c", type: "integer", inferred: "integer", hidden: true}
+      {name: "b", type: "integer", inferred: "integer"},
+      {name: "c", type: "integer", inferred: "integer"}
     ];
     assert.deepStrictEqual(
       __table(source, operationsSelectedColumns),


### PR DESCRIPTION
Part of https://github.com/observablehq/observablehq/issues/11623

## Description

This PR adds support for derived columns in the `__table` function. In this first version, we won't support derived columns for database sources.

Notable changes:
- Pulled the logic for inferring types and coercing rows into a separate `applyTypes` function. We now run this twice, first on the source dataset, and second on the derived dataset, before merging the two. Type inference/coercion must be done separately on the derived dataset because it may depend on values in the source dataset already being coerced.
- Added a `.fullSchema` property to the return value of `__table`. This property contains the schema information for _all_ columns in the dataset, regardless of whether or not they are selected (`.schema` only contains the schema info for selected columns). In https://github.com/observablehq/observablehq/pull/11214, we switch to using the cell value to get the table schema, because derived columns aren't available on the original dataset and their types may be dynamic, so we need to look at their evaluated runtime values. We look at `.fullSchema` when fetching the table schema so that we always have type information for the full set of columns, so that users can e.g. reselect a deselected column in the Columns menu.

## Review notes

I would love some feedback on the `.fullSchema` change! I'm not sure if it's the best way to make all the column types available, and I'm also not sure if I'm missing any major pitfalls with switching to use the cell value to fetch the table schema, instead of looking at the original data source as we do today. The main pitfall I experienced when testing is that, if there's an error in a derived formula, we no longer have a table schema available because the cell throws an error. I addressed that in the monorepo PR by adding a fallback that goes back to using the loaded data source + an approximation of the derived columns schema, which I think is the best we can do in that case. But perhaps there are other issues with this approach that I'm missing...