### PR TITLE
Remove index and rows as arguments to the derive expression

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -686,10 +686,11 @@ export function __table(source, operations) {
       // applied, because operations like filter and sort reference original
       // column names.
       // TODO Allow derived columns to reference other derived columns.
-      applyNames(source, operations).map((row, index, rows) => {
+      applyNames(source, operations).map((row, index) => {
         let resolved;
         try {
-          resolved = value(row, index, rows);
+          // TODO Support referencing `index` and `rows` in the derive function.
+          resolved = value(row);
         } catch (error) {
           columnErrors.push({index, error});
           resolved = undefined;


### PR DESCRIPTION
Accompanying compiler PR: https://github.com/observablehq/compiler/pull/87

Partially addresses https://github.com/observablehq/observablehq/issues/11974

Some context: during a recent column derivation bug bash, there was confusion about the `index` and `rows` properties in the derive formula because they represent the index and rows values from the original data source, not the index and rows as seen in the table display. This is the case because column derivations are computed before any filters, sorts, or other operations are applied, since those operations may reference derived columns. The decision was made to remove these arguments in order to avoid potential confusion – if we get user feedback requesting access to these values, we can figure out how to add them back in a way that makes more intuitive sense.