### PR TITLE
Catch more invalid data sources

### DIFF
--- a/src/table.js
+++ b/src/table.js
@@ -184,7 +184,7 @@ export async function loadDataSource(source, mode, name) {
 function sourceCache(loadSource) {
   const cache = new WeakMap();
   return (source, name) => {
-    if (!source) throw new Error("data source not found");
+    if (!source || !(source instanceof Object)) throw new Error("invalid data source");
     let promise = cache.get(source);
     if (!promise || (isDataArray(source) && source.length !== promise._numRows)) {
       // Warning: do not await here! We need to populate the cache synchronously.


### PR DESCRIPTION
Companion PR to https://github.com/observablehq/observablehq/pull/12427

If a user selects a cell with a primitive value, the call to `cache.get` throws an "invalid value used as WeakMap key" error. I think it's more informative to show "invalid data source" in that case, and in general I'd like to standardize the error message across all cases where the data source isn't valid.