### PR TITLE
5.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observablehq/stdlib",
-  "version": "5.7.7",
+  "version": "5.8.0",
   "author": {
     "name": "Observable, Inc.",
     "url": "https://observablehq.com"


### PR DESCRIPTION
i used to bump the version as part of `npm publish`, but it looks like i can't push directly to main anymore (was there a change in a the repo settings recently?).

anyway, this applies the version bump that i neglected to add to https://github.com/observablehq/stdlib/pull/381.