### PR TITLE
feat: add pizza paradise sample dataset

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -57,7 +57,7 @@ export const Library = Object.assign(Object.defineProperties(function Library(re
     vl: () => vl(require),
 
     // Sample datasets
-    // https://observablehq.com/@observablehq/datasets
+    // https://observablehq.com/@observablehq/sample-datasets
     aapl: () => new FileAttachment("https://static.observableusercontent.com/files/3ccff97fd2d93da734e76829b2b066eafdaac6a1fafdec0faf6ebc443271cfc109d29e80dd217468fcb2aff1e6bffdc73f356cc48feb657f35378e6abbbb63b9").csv({typed: true}),
     alphabet: () => new FileAttachment("https://static.observableusercontent.com/files/75d52e6c3130b1cae83cda89305e17b50f33e7420ef205587a135e8562bcfd22e483cf4fa2fb5df6dff66f9c5d19740be1cfaf47406286e2eb6574b49ffc685d").csv({typed: true}),
     cars: () => new FileAttachment("https://static.observableusercontent.com/files/048ec3dfd528110c0665dfa363dd28bc516ffb7247231f3ab25005036717f5c4c232a5efc7bb74bc03037155cb72b1abe85a33d86eb9f1a336196030443be4f6").csv({typed: true}),
@@ -68,6 +68,7 @@ export const Library = Object.assign(Object.defineProperties(function Library(re
     miserables: () => new FileAttachment("https://static.observableusercontent.com/files/31d904f6e21d42d4963ece9c8cc4fbd75efcbdc404bf511bc79906f0a1be68b5a01e935f65123670ed04e35ca8cae3c2b943f82bf8db49c5a67c85cbb58db052").json(),
     olympians: () => new FileAttachment("https://static.observableusercontent.com/files/31ca24545a0603dce099d10ee89ee5ae72d29fa55e8fc7c9ffb5ded87ac83060d80f1d9e21f4ae8eb04c1e8940b7287d179fe8060d887fb1f055f430e210007c").csv({typed: true}),
     penguins: () => new FileAttachment("https://static.observableusercontent.com/files/715db1223e067f00500780077febc6cebbdd90c151d3d78317c802732252052ab0e367039872ab9c77d6ef99e5f55a0724b35ddc898a1c99cb14c31a379af80a").csv({typed: true}),
+    pizza: () => new FileAttachment("https://static.observableusercontent.com/files/c653108ab176088cacbb338eaf2344c4f5781681702bd6afb55697a3f91b511c6686ff469f3e3a27c75400001a2334dbd39a4499fe46b50a8b3c278b7d2f7fb5").csv({typed: true}),
     weather: () => new FileAttachment("https://static.observableusercontent.com/files/693a46b22b33db0f042728700e0c73e836fa13d55446df89120682d55339c6db7cc9e574d3d73f24ecc9bc7eb9ac9a1e7e104a1ee52c00aab1e77eb102913c1f").csv({typed: true}),
 
     // Note: these are namespace objects, and thus exposed directly rather than

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -36,6 +36,7 @@ it("new Library returns a library with the expected keys", () => {
     "now",
     "olympians",
     "penguins",
+    "pizza",
     "require",
     "resolve",
     "svg",


### PR DESCRIPTION
- Adds shortened pizza paradise sample as `pizza` (verified unclaimed) to stdlib datasets. Already uploaded static file)
- Fixes "Sample datasets" link comment

---

- Works on internal # 13706
- Follows https://github.com/observablehq/stdlib/pull/284

Docs:
- https://observablehq.com/@observablehq/sample-datasets
- https://observablehq.com/@observablehq/pizza-paradise-data