### PR TITLE
chore: 5.8.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+See checklist for [publishing a new release](https://observablehq.com/@observablehq/publishing-new-open-source-releases).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@observablehq/stdlib",
-  "version": "5.8.1",
+  "version": "5.8.2",
   "author": {
     "name": "Observable, Inc.",
     "url": "https://observablehq.com"


### PR DESCRIPTION
Bumps package to 5.8.2.

It isn't clear how to release this package and it doesn't seem to have automated version bumping or releasing.