### PR TITLE
Reject pending promises when a generator is closed

### DIFF
--- a/test/generators/generators-test.js
+++ b/test/generators/generators-test.js
@@ -56,3 +56,19 @@ it("queue yields all values", async () => {
   assert.strictEqual(await q.next().value, 1);
   assert.strictEqual(await q.next().value, 2);
 });
+
+it("observe rejects pending promise on return", async () => {
+  let o = observe(() => {});
+  const pending = o.next().value;
+  o.return();
+  await assert.rejects(pending, /Generator returned/);
+});
+
+it("observe does not reject if no pending promise on return", async () => {
+  let o = observe(change => {
+    change(1);
+  });
+  assert.strictEqual(await o.next().value, 1);
+  // No pending promise, so return should complete without error
+  assert.deepStrictEqual(o.return(), {done: true});
+});


### PR DESCRIPTION
This treats an issue raised here https://github.com/observablehq/runtime/issues/376

V6 runtime will wait for prior promises to resolve, in the case of a generator like Generator.input, the initial value will wait for a truthy value, if the cell is invalidated, the initial value will never be resolved and the runtime is stuck.

In this change we reject any pending promises when a Generator is disposed, ensuring nothing gets hung. By rejecting we ensure nothing interprets this as an actual value.

I can confirm this fixes a behaviour I was observing when running Notebook 1.0 on Runtime v6.0
